### PR TITLE
Fix incorrect comment about removeDirectoryRecursive and symlinks

### DIFF
--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -460,9 +460,10 @@ removeDirectory path =
 
 #endif
 
--- | @'removeDirectoryRecursive' dir@  removes an existing directory /dir/
--- together with its content and all subdirectories. Be careful,
--- if the directory contains symlinks, the function will follow them.
+-- | @'removeDirectoryRecursive' dir@ removes an existing directory
+-- /dir/ together with its content and all subdirectories. If the
+-- directory contains symlinks this function removes but does not
+-- follow them.
 removeDirectoryRecursive :: FilePath -> IO ()
 removeDirectoryRecursive startLoc = do
   cont <- getDirectoryContents startLoc


### PR DESCRIPTION
removeDirectoryRecursive removes symlinks inside the directory before it has a chance to follow them.

Exception is the initial path, there symlink is followed. Arguably it should not be the case.
