### PR TITLE
renameFile now consistently reports an error if the destination is a directory

### DIFF
--- a/tests/T8482.hs
+++ b/tests/T8482.hs
@@ -1,0 +1,16 @@
+import System.Directory
+import Control.Exception
+
+tmp1 = "T8482.tmp1"
+testdir = "T8482.dir"
+
+main = do
+  writeFile tmp1 "hello"
+  createDirectory testdir
+  tryRenameFile testdir tmp1 >>= print  -- InappropriateType
+  tryRenameFile tmp1 testdir >>= print  -- InappropriateType
+  tryRenameFile tmp1 "." >>= print  -- InappropriateType
+  removeDirectory testdir
+  removeFile tmp1
+  where tryRenameFile :: FilePath -> FilePath -> IO (Either IOException ())
+        tryRenameFile opath npath = try $ renameFile opath npath

--- a/tests/T8482.stdout
+++ b/tests/T8482.stdout
@@ -1,0 +1,3 @@
+Left T8482.dir: renameFile: inappropriate type (is a directory)
+Left T8482.dir: renameFile: inappropriate type (is a directory)
+Left .: renameFile: inappropriate type (is a directory)

--- a/tests/all.T
+++ b/tests/all.T
@@ -27,3 +27,4 @@ test('createDirectoryIfMissing001',  normal, compile_and_run, [''])
 test('getHomeDirectory001',  ignore_output, compile_and_run, [''])
 
 test('T4113', when(platform('i386-apple-darwin'), expect_broken(7604)), compile_and_run, [''])
+test('T8482',  normal, compile_and_run, [''])


### PR DESCRIPTION
I only tested on Windows, could you please run the tests on Unix to make sure they are not broken?

https://ghc.haskell.org/trac/ghc/ticket/8482 is related.
