### PR TITLE
Make behavior of removeDirectoryRecursive more consistent

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,9 @@
 
   * Expose `findExecutables` [#14](https://github.com/haskell/directory/issues/14)
 
-  * Clarify conditions under which `removeDirectoryRecursive` may follow a symlink
+  * `removeDirectoryRecursive` no longer follows symlinks under any
+    circumstances, fixing the inconsistency as noted in
+    [#15](https://github.com/haskell/directory/issues/15)
 
 ## 1.2.1.0  *Mar 2014*
 


### PR DESCRIPTION
Fixes #15.

While the POSIX-like behavior is more elegant to implement, for backward compatibility `removeDirectoryRecursive` shall retain the Python-like behavior.  Another function `removePathRecursive` was added to implement the POSIX behavior, although it is currently not exported.