### PR TITLE
Update docs on Windows location of AppUserDataDirectory

### DIFF
--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -1124,7 +1124,7 @@ writable.
 On Unix, this function returns @$HOME\/.appName@.  On Windows, a
 typical path might be
 
-> C:/Documents And Settings/user/Application Data/appName
+> C:/Users/user/AppData/Roaming/appName
 
 The operation may fail with:
 


### PR DESCRIPTION
The location of AppUserDataDirectory since Windows Vista should be

    Users/user/AppData/Roaming

rather than the archaic

    Documents and Settings/user/Application Data

I think it's time for the docs to drop support for Windows XP :)