### PR TITLE
Implement `withCurrentDirectory`

### DIFF
--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -28,6 +28,7 @@ module System.Directory
     , getDirectoryContents
     , getCurrentDirectory
     , setCurrentDirectory
+    , withCurrentDirectory
 
     -- * Pre-defined directories
     , getHomeDirectory
@@ -1097,6 +1098,20 @@ setCurrentDirectory path =
 #else
   Posix.changeWorkingDirectory path
 #endif
+
+-- | Run a given 'IO' action inside the specified directory while
+-- preserving the directory we were in at the start.
+--
+-- This function can fail with the same exceptions that
+-- 'getCurrentDirectory' and 'setCurrentDirectory' can.
+--
+-- @since 1.2.3.0
+withCurrentDirectory :: FilePath -- ^ The path of the directory to execute in
+                     -> IO a -- ^ The action to execute
+                     -> IO a
+withCurrentDirectory dir action =
+  bracket getCurrentDirectory setCurrentDirectory $ \_ ->
+    setCurrentDirectory dir >> action
 
 {- |The operation 'doesDirectoryExist' returns 'True' if the argument file
 exists and is either a directory or a symbolic link to a directory,

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,8 @@ Changelog for the [`directory`][1] package
 
   * Deprecate use of `HsDirectory.h` and `HsDirectoryConfig.h`
 
+  * Implement `withCurrentDirectory`
+
 ## 1.2.2.1 (Apr 2015)
 
   * Fix dependency problem on NixOS when building with tests

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -16,6 +16,7 @@ import qualified GetPermissions001
 import qualified RemoveDirectoryRecursive001
 import qualified RenameFile001
 import qualified T8482
+import qualified WithCurrentDirectory
 
 main :: IO ()
 main = T.testMain $ \ _t -> do
@@ -35,3 +36,4 @@ main = T.testMain $ \ _t -> do
   T.isolatedRun _t "RemoveDirectoryRecursive001" RemoveDirectoryRecursive001.main
   T.isolatedRun _t "RenameFile001" RenameFile001.main
   T.isolatedRun _t "T8482" T8482.main
+  T.isolatedRun _t "WithCurrentDirectory" WithCurrentDirectory.main

--- a/tests/WithCurrentDirectory.hs
+++ b/tests/WithCurrentDirectory.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE CPP #-}
+module WithCurrentDirectory where
+#include "util.inl"
+import Data.Monoid ((<>))
+import Data.List (sort)
+import System.Directory
+import System.FilePath ((</>))
+
+main :: TestEnv -> IO ()
+main _t = do
+  createDirectory dir
+  -- Make sure we're starting empty
+  T(expectEq) () specials . sort =<< getDirectoryContents dir
+  cwd <- getCurrentDirectory
+  withCurrentDirectory dir (writeFile testfile contents)
+  -- Are we still in original directory?
+  T(expectEq) () cwd =<< getCurrentDirectory
+  -- Did the test file get created?
+  T(expectEq) () (specials <> [testfile]) . sort =<< getDirectoryContents dir
+  -- Does the file contain what we expected to write?
+  T(expectEq) () contents =<< readFile (dir </> testfile)
+  where
+    testfile = "testfile"
+    contents = "some data\n"
+    dir = "dir"
+    specials = [".", ".."]


### PR DESCRIPTION
This function allows us to perform an IO action in a different directory
without the hassle of manually switching and restoring the directory.