### PR TITLE
Add GHC build files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ dist/
 include/HsDirectoryConfig.h
 include/HsDirectoryConfig.h.in
 *~
+
+# In GHC build tree:
+GNUmakefile
+dist-install
+ghc.mk


### PR DESCRIPTION
I would like to update the directory `submodule` in the GHC tree, but I'm seeing:
```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	GNUmakefile
	dist-install/
	ghc.mk
```