### PR TITLE
Add getDirectoryContents' which ignores "." and ".."

### DIFF
--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -572,8 +572,8 @@ removePathRecursive path =
 removeContentsRecursive :: FilePath -> IO ()
 removeContentsRecursive path =
   (`ioeSetLocation` "removeContentsRecursive") `modifyIOError` do
-    cont <- getDirectoryContents path
-    mapM_ removePathRecursive [path </> x | x <- cont, x /= "." && x /= ".."]
+    cont <- getDirectoryContentsA path
+    mapM_ removePathRecursive [path </> x | x <- cont]
     removeDirectory path
 
 #if __GLASGOW_HASKELL__

--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -30,6 +30,7 @@ module System.Directory
     , removeDirectoryRecursive
     , renameDirectory
     , getDirectoryContents
+    , getDirectoryContentsA
     -- ** Current working directory
     , getCurrentDirectory
     , setCurrentDirectory
@@ -1029,6 +1030,15 @@ getDirectoryContents path =
           else return (filename:acc)
                  -- no need to reverse, ordering is undefined
 #endif /* mingw32 */
+
+{- | A version of 'getDirectoryContents' which returns /almost all/
+entries, ignoring the current and parent directories, @.@ and @..@.
+
+-}
+getDirectoryContentsA :: FilePath -> IO [FilePath]
+getDirectoryContentsA path =
+  (filter f) <$> (getDirectoryContents path)
+  where f filename = filename /= "." && filename /= ".."
 
 #endif /* __GLASGOW_HASKELL__ */
 

--- a/tests/CopyFile001.hs
+++ b/tests/CopyFile001.hs
@@ -3,19 +3,17 @@ module CopyFile001 where
 #include "util.inl"
 import System.Directory
 import Data.List (sort)
-import Data.Monoid ((<>))
 import System.FilePath ((</>))
 
 main :: TestEnv -> IO ()
 main _t = do
   createDirectory dir
   writeFile (dir </> from) contents
-  T(expectEq) () (specials <> [from]) . sort =<< getDirectoryContents dir
+  T(expectEq) () [from] . sort =<< getDirectoryContentsA dir
   copyFile (dir </> from) (dir </> to)
-  T(expectEq) () (specials <> [from, to]) . sort =<< getDirectoryContents dir
+  T(expectEq) () [from, to] . sort =<< getDirectoryContentsA dir
   T(expectEq) () contents =<< readFile (dir </> to)
   where
-    specials = [".", ".."]
     contents = "This is the data\n"
     from     = "source"
     to       = "target"

--- a/tests/CopyFile002.hs
+++ b/tests/CopyFile002.hs
@@ -3,19 +3,17 @@ module CopyFile002 where
 #include "util.inl"
 import System.Directory
 import Data.List (sort)
-import Data.Monoid ((<>))
 
 main :: TestEnv -> IO ()
 main _t = do
   -- Similar to CopyFile001 but moves a file in the current directory
   -- (Bug #1652 on GHC Trac)
   writeFile from contents
-  T(expectEq) () (specials <> [from]) . sort =<< getDirectoryContents "."
+  T(expectEq) () [from] . sort =<< getDirectoryContentsA "."
   copyFile from to
-  T(expectEq) () (specials <> [from, to]) . sort =<< getDirectoryContents "."
+  T(expectEq) () [from, to] . sort =<< getDirectoryContentsA "."
   T(expectEq) () contents =<< readFile to
   where
-    specials = [".", ".."]
     contents = "This is the data\n"
     from     = "source"
     to       = "target"

--- a/tests/GetDirContents001.hs
+++ b/tests/GetDirContents001.hs
@@ -10,13 +10,10 @@ import System.FilePath  ((</>))
 main :: TestEnv -> IO ()
 main _t = do
   createDirectory dir
-  T(expectEq) () specials . sort =<< getDirectoryContents dir
   T(expectEq) () [] . sort =<< getDirectoryContentsA dir
   names <- for [1 .. 100 :: Int] $ \ i -> do
     let name = 'f' : show i
     writeFile (dir </> name) ""
     return name
-  T(expectEq) () (sort (specials <> names)) . sort =<< getDirectoryContents dir
-  T(expectEq) () (sort (names)) . sort =<< getDirectoryContentsA dir
+  T(expectEq) () (sort names) . sort =<< getDirectoryContentsA dir
   where dir      = "dir"
-        specials = [".", ".."]

--- a/tests/GetDirContents001.hs
+++ b/tests/GetDirContents001.hs
@@ -11,10 +11,12 @@ main :: TestEnv -> IO ()
 main _t = do
   createDirectory dir
   T(expectEq) () specials . sort =<< getDirectoryContents dir
+  T(expectEq) () [] . sort =<< getDirectoryContentsA dir
   names <- for [1 .. 100 :: Int] $ \ i -> do
     let name = 'f' : show i
     writeFile (dir </> name) ""
     return name
   T(expectEq) () (sort (specials <> names)) . sort =<< getDirectoryContents dir
+  T(expectEq) () (sort (names)) . sort =<< getDirectoryContentsA dir
   where dir      = "dir"
         specials = [".", ".."]

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -41,10 +41,10 @@ copyPathRecursive source dest =
     dirExists <- doesDirectoryExist source
     if dirExists
       then do
-        contents <- getDirectoryContents source
+        contents <- getDirectoryContentsA source
         createDirectory dest
         mapM_ (uncurry copyPathRecursive)
-          [(source </> x, dest </> x) | x <- contents, x /= "." && x /= ".."]
+          [(source </> x, dest </> x) | x <- contents]
       else copyFile source dest
 
 modifyPermissions :: FilePath -> (Permissions -> Permissions) -> IO ()

--- a/tests/WithCurrentDirectory.hs
+++ b/tests/WithCurrentDirectory.hs
@@ -10,17 +10,16 @@ main :: TestEnv -> IO ()
 main _t = do
   createDirectory dir
   -- Make sure we're starting empty
-  T(expectEq) () specials . sort =<< getDirectoryContents dir
+  T(expectEq) () [] . sort =<< getDirectoryContentsA dir
   cwd <- getCurrentDirectory
   withCurrentDirectory dir (writeFile testfile contents)
   -- Are we still in original directory?
   T(expectEq) () cwd =<< getCurrentDirectory
   -- Did the test file get created?
-  T(expectEq) () (specials <> [testfile]) . sort =<< getDirectoryContents dir
+  T(expectEq) () [testfile] . sort =<< getDirectoryContentsA dir
   -- Does the file contain what we expected to write?
   T(expectEq) () contents =<< readFile (dir </> testfile)
   where
     testfile = "testfile"
     contents = "some data\n"
     dir = "dir"
-    specials = [".", ".."]


### PR DESCRIPTION
getDirectoryContents returns the "." and ".." special directories. However in most cases user do not care about theses values and must manually filter them. This pull request introduces the getDirectoryContents' variant which handle this filtering. I find this really convenient when working with directory listing. Other languages uses the same trick (such as python, with os.listdir(),

Discussion: should we update *removeContentsRecursive* to use getDirectoryContents' instead of the explicit manual filtering of "." and ".." ?