### PR TITLE
Add undefinedPermissions which is useful for Unixy.Dry

### DIFF
--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -70,6 +70,7 @@ module System.Directory
 
     , Permissions
     , emptyPermissions
+    , undefinedPermissions
     , readable
     , writable
     , executable
@@ -223,6 +224,14 @@ emptyPermissions = Permissions {
                        writable   = False,
                        executable = False,
                        searchable = False
+                   }
+
+undefinedPermissions :: Permissions
+undefinedPermissions = Permissions {
+                       readable   = undefined,
+                       writable   = undefined,
+                       executable = undefined,
+                       searchable = undefined
                    }
 
 setOwnerReadable :: Bool -> Permissions -> Permissions


### PR DESCRIPTION
What follows is a discussion concerning its applicability in
Unixy.Dry, which I'm in the process of writing (in another package):

undefinedPermissions is more reasonable than emptyPermissions in a
context of a general dry-run because it makes sure that we do not make
decisions based on fake permissions. (If such a need arises, we should
probably explicitly define a special context, that would somehow
supply a special implementation for dryValue.)

A disturbing issue with using undefinedPermissions is that we won't be
able to "show" the dry-run actions. Well, a way out would be :print in
GHCi (after forcing the skeleton of the data) -- since, anyway, a
dry-run is mostly for debugging before doing the switch to another
Unixy instance (backend).

(Also showing the undefined values could be implemented somehow with some other
method described at [1] like packman.)

[1]: http://stackoverflow.com/q/22272453/94687 "How do I serialize or save to a file a Thunk?"