### PR TITLE
Fix CPP usage

### DIFF
--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -635,7 +635,7 @@ The operand refers to an existing directory.
 
 removeFile :: FilePath -> IO ()
 removeFile path =
-#if mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
   Win32.deleteFile path
 #else
   Posix.removeLink path

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -52,7 +52,7 @@ modifyPermissions path modify = do
   permissions <- getPermissions path
   setPermissions path (modify permissions)
 
-#if mingw32_HOST_OS
+#ifdef mingw32_HOST_OS
 createSymbolicLink :: String -> String -> IO ()
 createSymbolicLink target link =
   (`ioeSetLocation` "createSymbolicLink") `modifyIOError` do


### PR DESCRIPTION
The code had a a mixture of `#ifdef mingw32_HOST_OS` and `#if ..`. The
later works, but is not really correct. GHC HEAD now has a `-Wcpp-undef`
warning that we would like to turn on and hence need this fixed.