### PR TITLE
More work on canonicalizePath

### DIFF
--- a/System/Directory/Internal/Prelude.hs
+++ b/System/Directory/Internal/Prelude.hs
@@ -144,6 +144,7 @@ import System.IO
 import System.IO.Error
   ( IOError
   , catchIOError
+  , illegalOperationErrorType
   , ioeGetErrorString
   , ioeGetErrorType
   , ioeGetLocation
@@ -152,6 +153,7 @@ import System.IO.Error
   , ioeSetLocation
   , isAlreadyExistsError
   , isDoesNotExistError
+  , isIllegalOperation
   , isPermissionError
   , mkIOError
   , modifyIOError

--- a/System/Directory/Internal/windows.h
+++ b/System/Directory/Internal/windows.h
@@ -1,0 +1,29 @@
+#include <windows.h>
+
+// define prototype to get size, offsets, and alignments
+// (can't include <ntifs.h> because that only exists in WDK)
+typedef struct {
+    ULONG ReparseTag;
+    USHORT ReparseDataLength;
+    USHORT Reserved;
+    union {
+        struct {
+            USHORT SubstituteNameOffset;
+            USHORT SubstituteNameLength;
+            USHORT PrintNameOffset;
+            USHORT PrintNameLength;
+            ULONG Flags;
+            WCHAR PathBuffer[1];
+        } SymbolicLinkReparseBuffer;
+        struct {
+            USHORT SubstituteNameOffset;
+            USHORT SubstituteNameLength;
+            USHORT PrintNameOffset;
+            USHORT PrintNameLength;
+            WCHAR PathBuffer[1];
+        } MountPointReparseBuffer;
+        struct {
+            UCHAR DataBuffer[1];
+        } GenericReparseBuffer;
+    };
+} HsDirectory_REPARSE_DATA_BUFFER;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,8 @@ environment:
     STACK: stack --skip-msys --resolver lts-5
   - DEPS: Win32-2.3.0.1
     STACK: stack --skip-msys --resolver lts-2
-    PREBUILD: sed -i.bak /GetFinalPathNameByHandleW/d configure.ac
+    PREBUILD: sed -i.bak -e /CreateSymbolicLinkW/d
+                         -e /GetFinalPathNameByHandleW/d configure.ac
 cache:
 - "%STACK_ROOT%"
 install:

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,9 @@ Changelog for the [`directory`][1] package
       * `removeDirectoryLink`
       * `getSymbolicLinkTarget`
 
+  * `canonicalizePath` can now resolve broken symbolic links too.
+    ([#64](https://github.com/haskell/directory/issues/64))
+
 ## 1.3.0.2 (February 2017)
 
   * [optimization] Increase internal buffer size of `copyFile`

--- a/changelog.md
+++ b/changelog.md
@@ -1,12 +1,28 @@
 Changelog for the [`directory`][1] package
 ==========================================
 
-## 1.3.0.3 (March 2017)
+## 1.3.1.0 (March 2017)
 
   * `findFile` (and similar functions): when an absolute path is given, the
     list of search directories is now completely ignored.  Previously, if the
     list was empty, `findFile` would always fail.
     ([#72](https://github.com/haskell/directory/issues/72))
+
+  * For symbolic links on Windows, the following functions had previously
+    interpreted paths as referring to the links themselves rather than their
+    targets.  This was inconsistent with other platforms and has been fixed.
+      * `getFileSize`
+      * `doesPathExist`
+      * `doesDirectoryExist`
+      * `doesFileExist`
+
+  * Fix incorrect location info in errors from `pathIsSymbolicLink`.
+
+  * Add functions for symbolic link manipulation:
+      * `createFileLink`
+      * `createDirectoryLink`
+      * `removeDirectoryLink`
+      * `getSymbolicLinkTarget`
 
 ## 1.3.0.2 (February 2017)
 

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,7 @@ AC_PROG_CC()
 AC_CHECK_HEADERS([fcntl.h limits.h sys/types.h sys/stat.h time.h])
 
 AC_CHECK_FUNCS([utimensat])
+AC_CHECK_FUNCS([CreateSymbolicLinkW])
 AC_CHECK_FUNCS([GetFinalPathNameByHandleW])
 
 # EXTEXT is defined automatically by AC_PROG_CC;

--- a/directory.cabal
+++ b/directory.cabal
@@ -1,5 +1,5 @@
 name:           directory
-version:        1.3.0.3
+version:        1.3.1.0
 -- NOTE: Don't forget to update ./changelog.md
 license:        BSD3
 license-file:   LICENSE

--- a/tests/CanonicalizePath.hs
+++ b/tests/CanonicalizePath.hs
@@ -81,10 +81,18 @@ main _t = do
     T(expectEq) () bar =<< canonicalizePath "lfoo/bar"
     T(expectEq) () barQux =<< canonicalizePath "lfoo/bar/qux"
 
-    -- FIXME: uncomment this test once #64 is fixed
-    -- createSymbolicLink "../foo/non-existent" "foo/qux"
-    -- qux <- canonicalizePath "foo/qux"
-    -- T(expectEq) () qux (dot </> "../foo/non-existent")
+    -- regression test for #64
+    createFileLink "../foo/non-existent" "foo/qux"
+    qux <- canonicalizePath "foo/qux"
+    T(expectEq) () qux =<< canonicalizePath "foo/non-existent"
+
+    -- make sure it can handle loops
+    createFileLink "loop1" "loop2"
+    createFileLink "loop2" "loop1"
+    loop1 <- canonicalizePath "loop1"
+    loop2 <- canonicalizePath "loop2"
+    T(expectEq) () loop1 (normalise (dot </> "loop1"))
+    T(expectEq) () loop2 (normalise (dot </> "loop2"))
 
   caseInsensitive <-
     (False <$ createDirectory "FOO")

--- a/tests/RemoveDirectoryRecursive001.hs
+++ b/tests/RemoveDirectoryRecursive001.hs
@@ -26,9 +26,9 @@ main _t = do
   createDirectoryIfMissing True (tmp "c")
   writeFile (tmp "a/x/w/u") "foo"
   writeFile (tmp "a/t")     "bar"
-  tryCreateSymbolicLink (normalise "../a") (tmp "b/g")
-  tryCreateSymbolicLink (normalise "../b") (tmp "c/h")
-  tryCreateSymbolicLink (normalise "a")    (tmp "d")
+  symlinkOrCopy (normalise "../a") (tmp "b/g")
+  symlinkOrCopy (normalise "../b") (tmp "c/h")
+  symlinkOrCopy (normalise "a")    (tmp "d")
   modifyPermissions (tmp "c") (\ p -> p { writable = False })
 
   ------------------------------------------------------------

--- a/tests/RemovePathForcibly.hs
+++ b/tests/RemovePathForcibly.hs
@@ -28,9 +28,9 @@ main _t = do
   writeFile (tmp "a/x/w/u") "foo"
   writeFile (tmp "a/t")     "bar"
   writeFile (tmp "f/s")     "qux"
-  tryCreateSymbolicLink (normalise "../a") (tmp "b/g")
-  tryCreateSymbolicLink (normalise "../b") (tmp "c/h")
-  tryCreateSymbolicLink (normalise "a")    (tmp "d")
+  symlinkOrCopy (normalise "../a") (tmp "b/g")
+  symlinkOrCopy (normalise "../b") (tmp "c/h")
+  symlinkOrCopy (normalise "a")    (tmp "d")
   setPermissions (tmp "f/s") emptyPermissions
   setPermissions (tmp "f") emptyPermissions
 

--- a/tests/TestUtils.hs
+++ b/tests/TestUtils.hs
@@ -1,31 +1,18 @@
-{-# LANGUAGE CPP, ForeignFunctionInterface #-}
+{-# LANGUAGE CPP #-}
+-- | Utility functions specific to 'directory' tests
 module TestUtils
   ( copyPathRecursive
-  , createSymbolicLink
   , modifyPermissions
-  , tryCreateSymbolicLink
+  , symlinkOrCopy
+  , supportsSymlinks
   ) where
 import Prelude ()
 import System.Directory.Internal.Prelude
 import System.Directory
-import System.FilePath ((</>))
+import System.FilePath ((</>), normalise, takeDirectory)
 #ifdef mingw32_HOST_OS
-import System.FilePath (takeDirectory)
+import System.Directory.Internal (win32_getFinalPathNameByHandle)
 import qualified System.Win32 as Win32
-#else
-import System.Posix (createSymbolicLink)
-#endif
-
-#ifdef mingw32_HOST_OS
-# if defined i386_HOST_ARCH
-#  define WINAPI stdcall
-# elif defined x86_64_HOST_ARCH
-#  define WINAPI ccall
-# else
-#  error unknown architecture
-# endif
-foreign import WINAPI unsafe "windows.h CreateSymbolicLinkW"
-  c_CreateSymbolicLink :: Ptr CWchar -> Ptr CWchar -> CULong -> IO CUChar
 #endif
 
 -- | @'copyPathRecursive' path@ copies an existing file or directory at
@@ -49,37 +36,61 @@ modifyPermissions path modify = do
   permissions <- getPermissions path
   setPermissions path (modify permissions)
 
-#ifdef mingw32_HOST_OS
-createSymbolicLink :: String -> String -> IO ()
-createSymbolicLink target link =
-  (`ioeSetLocation` "createSymbolicLink") `modifyIOError` do
-    isDir <- (fromIntegral . fromEnum) `fmap`
-             doesDirectoryExist (takeDirectory link </> target)
-    let target' = fixSlash <$> target
-    withCWString target' $ \ pTarget ->
-      withCWString link $ \ pLink -> do
-        status <- c_CreateSymbolicLink pLink pTarget isDir
-        if status == 0
-          then do
-            errCode <- Win32.getLastError
-            if errCode == c_ERROR_PRIVILEGE_NOT_HELD
-              then ioError . (`ioeSetErrorString` permissionErrorMsg) $
-                   mkIOError permissionErrorType "" Nothing (Just link)
-              else Win32.failWith "createSymbolicLink" errCode
-          else return ()
-  where c_ERROR_PRIVILEGE_NOT_HELD = 0x522
-        permissionErrorMsg = "no permission to create symbolic links"
-        fixSlash '/' = '\\'
-        fixSlash c   = c
-#endif
-
--- | Attempt to create a symbolic link.  On Windows, this falls back to
---   copying if forbidden due to Group Policies.
-tryCreateSymbolicLink :: FilePath -> FilePath -> IO ()
-tryCreateSymbolicLink target link = createSymbolicLink target link
+-- | On Windows, the handler is called if symbolic links are unsupported or
+-- the user lacks the necessary privileges to create them.  On other
+-- platforms, the handler is never run.
+handleSymlinkUnavail
+  :: IO a                               -- ^ handler
+  -> IO a                               -- ^ arbitrary action
+  -> IO a
+handleSymlinkUnavail _handler action = action
 #ifdef mingw32_HOST_OS
   `catchIOError` \ e ->
-    if isPermissionError e
-    then copyPathRecursive (takeDirectory link </> target) link
-    else ioError e
+    case ioeGetErrorType e of
+      UnsupportedOperation -> _handler
+      _ | isIllegalOperation e || isPermissionError e -> _handler
+      _ -> ioError e
+#endif
+
+-- | Create a symbolic link.  On Windows, this falls back to copying if
+-- forbidden by Group Policy or is not supported.  On other platforms, there
+-- is no fallback.  Also, automatically detect if the source is a file or a
+-- directory and create the appropriate type of link.
+symlinkOrCopy :: FilePath -> FilePath -> IO ()
+symlinkOrCopy target link = do
+  let fullTarget = takeDirectory link </> target
+  handleSymlinkUnavail (copyPathRecursive fullTarget link) $ do
+    isDir <- doesDirectoryExist fullTarget
+    (if isDir then createDirectoryLink else createFileLink)
+      (normalise target)
+      link
+
+supportsSymlinks :: IO Bool
+supportsSymlinks = do
+  canCreate <- supportsLinkCreation
+  canDeref <- supportsLinkDeref
+  return (canCreate && canDeref)
+
+-- | On Windows, test if symbolic link creation is supported and the user has
+-- the necessary privileges to create them.  On other platforms, this always
+-- returns 'True'.
+supportsLinkCreation :: IO Bool
+supportsLinkCreation = do
+  let path = "_symlink_test.tmp"
+  isSupported <- handleSymlinkUnavail (return False) $ do
+    True <$ createFileLink path path
+  when isSupported $ do
+    removeFile path
+  return isSupported
+
+supportsLinkDeref :: IO Bool
+supportsLinkDeref = do
+#ifdef mingw32_HOST_OS
+    True <$ win32_getFinalPathNameByHandle Win32.nullHANDLE 0
+  `catchIOError` \ e ->
+    case ioeGetErrorType e of
+      UnsupportedOperation -> return False
+      _ -> return True
+#else
+    return True
 #endif

--- a/tests/Util.hs
+++ b/tests/Util.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+-- | A rudimentary testing framework
 module Util where
 import Prelude ()
 import System.Directory.Internal.Prelude

--- a/tools/testctl
+++ b/tools/testctl
@@ -15,14 +15,12 @@ Usage:
 
 """[1:]
 
-LIBRARY = "System.Directory"
 TEST_DIR = "tests"
 TEST_EXT = ".hs"
 TEST_TEMPLATE = """
 {{-# LANGUAGE CPP #-}}
 module {name} where
 #include "util.inl"
-import {library}
 
 main :: TestEnv -> IO ()
 main _t = do
@@ -84,7 +82,7 @@ def add(name):
                          .format(program, filename))
         sys.exit(1)
     with open(filename, "wb") as file:
-        file.write(TEST_TEMPLATE.format(name=name, library=LIBRARY)
+        file.write(TEST_TEMPLATE.format(name=name)
                    .encode("utf8"))
     update()
     print("{0}: test added: {1}".format(program, filename))


### PR DESCRIPTION
- [x] Clean up the imports using an internal prelude
- [x] Add case canonicalization
- [x] Add symbolic link dereferencing
- [x] Make error messages more useful
- [x] https://github.com/haskell/directory/issues/64
    - [x] Add `CreateSymbolicLink` from the `TestUtil` module
    - [x] Check edge case behavior of symbolic link functions
         - [x] Windows XP: `readSymbolicLink` works fine; `CreateSymbolicLink` and `GetFinalPathName` both cause `UnsupportedOperation`
         - [x] FAT32: both `readSymbolicLink` and `createSymbolicLink` cause `illegalOperation`.
    - [x] Fix `canonicalizePath`