### PR TITLE
Win32: bump to 2.6

### DIFF
--- a/directory.cabal
+++ b/directory.cabal
@@ -58,7 +58,7 @@ Library
         time     >= 1.4 && < 1.8,
         filepath >= 1.3 && < 1.5
     if os(windows)
-        build-depends: Win32 >= 2.2.2 && < 2.5
+        build-depends: Win32 >= 2.2.2 && < 2.6
     else
         build-depends: unix >= 2.5.1 && < 2.8
 


### PR DESCRIPTION
I'd like to deploy Win32 2.5 with GHC 8.4 but the version bounds on Directory are currently preventing this. As such I'd like to bump the bounds in Directory as well.

The release log for 2.5 is here https://github.com/haskell/win32/releases/tag/v2.5.0.0