### PR TITLE
Reduce system call overhead of `copyFile` by increasing the buffer size to 128 KiB

### DIFF
--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -896,7 +896,7 @@ copyHandleData hFrom hTo =
   (`ioeAddLocation` "copyData") `modifyIOError` do
     allocaBytes bufferSize go
   where
-    bufferSize = 1024
+    bufferSize = 131072 -- 128 KiB, as coreutils `cp` uses as of May 2014 (see ioblksize.h)
     go buffer = do
       count <- hGetBuf hFrom buffer bufferSize
       when (count > 0) $ do


### PR DESCRIPTION
128 KiB is what coreutils `cp` uses, based on a benchmark provided here:
http://git.savannah.gnu.org/cgit/coreutils.git/tree/src/ioblksize.h?id=c0a79542fb5c2c22cf0a250db94af6f8581ca342#n23

The benchmarks report speedups of factor 5x to 30x depending on
the hardware.