### PR TITLE
Bump time upper bound

### DIFF
--- a/directory.cabal
+++ b/directory.cabal
@@ -55,7 +55,7 @@ Library
 
     build-depends:
         base     >= 4.5 && < 4.11,
-        time     >= 1.4 && < 1.8,
+        time     >= 1.4 && < 1.9,
         filepath >= 1.3 && < 1.5
     if os(windows)
         build-depends: Win32 >= 2.2.2 && < 2.6


### PR DESCRIPTION
This (along with a new minor release) is needed for GHC 8.2.