### PR TITLE
Fix Win32 2.6 support

### DIFF
--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -731,7 +731,11 @@ renamePath opath npath = (`ioeAddLocation` "renamePath") `modifyIOError` do
    (`ioeSetFileName` opath) `modifyIOError` do
      opath' <- toExtendedLengthPath <$> prependCurrentDirectory opath
      npath' <- toExtendedLengthPath <$> prependCurrentDirectory npath
+#  if MIN_VERSION_Win32(2,6,0)
+     Win32.moveFileEx opath' (Just npath') Win32.mOVEFILE_REPLACE_EXISTING
+#  else
      Win32.moveFileEx opath' npath' Win32.mOVEFILE_REPLACE_EXISTING
+#  endif
 #else
    Posix.rename opath npath
 #endif
@@ -1106,7 +1110,11 @@ makeRelativeToCurrentDirectory x = do
 findExecutable :: String -> IO (Maybe FilePath)
 findExecutable binary = do
 #if defined(mingw32_HOST_OS)
+#  if MIN_VERSION_Win32(2,6,0)
+    Win32.searchPath Nothing binary (Just exeExtension)
+#  else
     Win32.searchPath Nothing binary exeExtension
+# endif
 #else
     path <- getPath
     findFileWith isExecutable path (binary <.> exeExtension)

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 Changelog for the [`directory`][1] package
 ==========================================
 
+## Unreleased
+
+  * Fix `Win32` version 2.6 compatibility.
+
 ## 1.3.1.3 (September 2017)
 
   * Relax `Win32` version bounds to support 2.6.


### PR DESCRIPTION
Win32 2.6 has some backwards incompatible API changes.
Directory uses two of these functions that have a new API, as such relaxing the constraint to support 2.6 requires some minor code changes.

