### PR TITLE
Bump upper bound on unix to < 2.9

### DIFF
--- a/directory.cabal
+++ b/directory.cabal
@@ -61,7 +61,7 @@ Library
     if os(windows)
         build-depends: Win32 >= 2.2.2 && < 2.8
     else
-        build-depends: unix >= 2.5.1 && < 2.8
+        build-depends: unix >= 2.5.1 && < 2.9
 
     ghc-options: -Wall
 


### PR DESCRIPTION
See https://ghc.haskell.org/trac/ghc/ticket/15042.