### PR TITLE
Document possible failures of removing directories on Windows

### DIFF
--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -401,6 +401,8 @@ removeDirectory = removePathInternal True
 -- together with its contents and subdirectories. Within this directory,
 -- symbolic links are removed without affecting their targets.
 --
+-- On Windows, the operation fails if /dir/ is a directory symbolic link.
+--
 -- This operation is reported to be flaky on Windows so retry logic may be advisable.
 -- See: [github.com/haskell/directory/pull/108](https://github.com/haskell/directory/pull/108)
 removeDirectoryRecursive :: FilePath -> IO ()

--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -401,9 +401,8 @@ removeDirectory = removePathInternal True
 -- together with its contents and subdirectories. Within this directory,
 -- symbolic links are removed without affecting their targets.
 --
--- On Windows, the operation fails if /dir/ is a directory symbolic link. 
--- Rarely, the operation may also fail on Windows if a directory is removed 
--- immediately after a child directory.
+-- This operation is reported to be flaky on Windows so retry logic may be advisable.
+-- See: [github.com/haskell/directory/pull/108](https://github.com/haskell/directory/pull/108)
 removeDirectoryRecursive :: FilePath -> IO ()
 removeDirectoryRecursive path =
   (`ioeAddLocation` "removeDirectoryRecursive") `modifyIOError` do
@@ -421,8 +420,8 @@ removeDirectoryRecursive path =
 -- /path/ together with its contents and subdirectories. Symbolic links are
 -- removed without affecting their the targets.
 --
--- Rarely, the operation may also fail on Windows if a directory is removed 
--- immediately after a child directory.
+-- This operation is reported to be flaky on Windows so retry logic may be advisable.
+-- See: [github.com/haskell/directory/pull/108](https://github.com/haskell/directory/pull/108)
 removePathRecursive :: FilePath -> IO ()
 removePathRecursive path =
   (`ioeAddLocation` "removePathRecursive") `modifyIOError` do
@@ -436,8 +435,8 @@ removePathRecursive path =
 -- /dir/ recursively. Symbolic links are removed without affecting their the
 -- targets.
 --
--- Rarely, the operation may also fail on Windows if a directory is removed 
--- immediately after a child directory.
+-- This operation is reported to be flaky on Windows so retry logic may be advisable.
+-- See: [github.com/haskell/directory/pull/108](https://github.com/haskell/directory/pull/108)
 removeContentsRecursive :: FilePath -> IO ()
 removeContentsRecursive path =
   (`ioeAddLocation` "removeContentsRecursive") `modifyIOError` do

--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -403,8 +403,8 @@ removeDirectory = removePathInternal True
 --
 -- On Windows, the operation fails if /dir/ is a directory symbolic link.
 --
--- This operation is reported to be flaky on Windows so retry logic may be advisable.
--- See: [github.com/haskell/directory/pull/108](https://github.com/haskell/directory/pull/108)
+-- This operation is reported to be flaky on Windows so retry logic may 
+-- be advisable. See: https://github.com/haskell/directory/pull/108
 removeDirectoryRecursive :: FilePath -> IO ()
 removeDirectoryRecursive path =
   (`ioeAddLocation` "removeDirectoryRecursive") `modifyIOError` do
@@ -422,8 +422,8 @@ removeDirectoryRecursive path =
 -- /path/ together with its contents and subdirectories. Symbolic links are
 -- removed without affecting their the targets.
 --
--- This operation is reported to be flaky on Windows so retry logic may be advisable.
--- See: [github.com/haskell/directory/pull/108](https://github.com/haskell/directory/pull/108)
+-- This operation is reported to be flaky on Windows so retry logic may 
+-- be advisable. See: https://github.com/haskell/directory/pull/108
 removePathRecursive :: FilePath -> IO ()
 removePathRecursive path =
   (`ioeAddLocation` "removePathRecursive") `modifyIOError` do
@@ -437,8 +437,8 @@ removePathRecursive path =
 -- /dir/ recursively. Symbolic links are removed without affecting their the
 -- targets.
 --
--- This operation is reported to be flaky on Windows so retry logic may be advisable.
--- See: [github.com/haskell/directory/pull/108](https://github.com/haskell/directory/pull/108)
+-- This operation is reported to be flaky on Windows so retry logic may 
+-- be advisable. See: https://github.com/haskell/directory/pull/108
 removeContentsRecursive :: FilePath -> IO ()
 removeContentsRecursive path =
   (`ioeAddLocation` "removeContentsRecursive") `modifyIOError` do

--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -401,7 +401,9 @@ removeDirectory = removePathInternal True
 -- together with its contents and subdirectories. Within this directory,
 -- symbolic links are removed without affecting their targets.
 --
--- On Windows, the operation fails if /dir/ is a directory symbolic link.
+-- On Windows, the operation fails if /dir/ is a directory symbolic link. 
+-- Rarely, the operation may also fail on Windows if a directory is removed 
+-- immediately after a child directory.
 removeDirectoryRecursive :: FilePath -> IO ()
 removeDirectoryRecursive path =
   (`ioeAddLocation` "removeDirectoryRecursive") `modifyIOError` do
@@ -418,6 +420,9 @@ removeDirectoryRecursive path =
 -- | @removePathRecursive path@ removes an existing file or directory at
 -- /path/ together with its contents and subdirectories. Symbolic links are
 -- removed without affecting their the targets.
+--
+-- Rarely, the operation may also fail on Windows if a directory is removed 
+-- immediately after a child directory.
 removePathRecursive :: FilePath -> IO ()
 removePathRecursive path =
   (`ioeAddLocation` "removePathRecursive") `modifyIOError` do
@@ -430,6 +435,9 @@ removePathRecursive path =
 -- | @removeContentsRecursive dir@ removes the contents of the directory
 -- /dir/ recursively. Symbolic links are removed without affecting their the
 -- targets.
+--
+-- Rarely, the operation may also fail on Windows if a directory is removed 
+-- immediately after a child directory.
 removeContentsRecursive :: FilePath -> IO ()
 removeContentsRecursive path =
   (`ioeAddLocation` "removeContentsRecursive") `modifyIOError` do


### PR DESCRIPTION
Hello,

Recently, I have come across a rare but reproducible problem on Windows [here](https://github.com/jaspervdj/hakyll/pull/783). Removing directories recursively using `removeDirectoryRecursive` would sometimes fail. This has been documented in many places, including in #96. 

This pull request documents this behavior for future users.