### PR TITLE
Allow Win32-2.9

### DIFF
--- a/directory.cabal
+++ b/directory.cabal
@@ -58,7 +58,7 @@ Library
         time     >= 1.4 && < 1.11,
         filepath >= 1.3 && < 1.5
     if os(windows)
-        build-depends: Win32 >= 2.2.2 && < 2.9
+        build-depends: Win32 >= 2.2.2 && < 2.10
     else
         build-depends: unix >= 2.5.1 && < 2.9
 


### PR DESCRIPTION
This will be necessary for GHC 9.0 due to the introduction of WinIO.