### PR TITLE
Bump base upper bound to 4.16

### DIFF
--- a/directory.cabal
+++ b/directory.cabal
@@ -54,7 +54,7 @@ Library
     include-dirs: .
 
     build-depends:
-        base     >= 4.5 && < 4.16,
+        base     >= 4.5 && < 4.17,
         time     >= 1.4 && < 1.11,
         filepath >= 1.3 && < 1.5
     if os(windows)


### PR DESCRIPTION
Context: https://gitlab.haskell.org/ghc/ghc/-/merge_requests/4082#note_300462