### PR TITLE
Bump bounds and enforce Safe Haskell status

### DIFF
--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -3,6 +3,8 @@
 #if !MIN_VERSION_base(4, 8, 0)
 -- In base-4.8.0 the Foreign module became Safe
 {-# LANGUAGE Trustworthy #-}
+#else
+{-# LANGUAGE Safe #-}
 #endif
 
 -----------------------------------------------------------------------------

--- a/System/Directory/Internal.hs
+++ b/System/Directory/Internal.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE Safe #-}
 -- |
 -- Stability: unstable
 -- Portability: unportable

--- a/System/Directory/Internal/Posix.hsc
+++ b/System/Directory/Internal/Posix.hsc
@@ -1,3 +1,5 @@
+{-# LANGUAGE Safe #-}
+
 module System.Directory.Internal.Posix where
 #include <HsDirectoryConfig.h>
 #if !defined(mingw32_HOST_OS)

--- a/directory.cabal
+++ b/directory.cabal
@@ -58,7 +58,7 @@ Library
         time     >= 1.4 && < 1.11,
         filepath >= 1.3 && < 1.5
     if os(windows)
-        build-depends: Win32 >= 2.2.2 && < 2.10
+        build-depends: Win32 >= 2.2.2 && < 2.11
     else
         build-depends: unix >= 2.5.1 && < 2.9
 

--- a/directory.cabal
+++ b/directory.cabal
@@ -55,7 +55,7 @@ Library
 
     build-depends:
         base     >= 4.5 && < 4.17,
-        time     >= 1.4 && < 1.11,
+        time     >= 1.4 && < 1.12,
         filepath >= 1.3 && < 1.5
     if os(windows)
         build-depends: Win32 >= 2.2.2 && < 2.11


### PR DESCRIPTION
Bumps the upper bounds for `Win32` and `time` and mark modules as Safe to ensure that we catch regressions (which recently happened in the `time` library).