### PR TITLE
Bump time upper bound to accommodate 2.11

### DIFF
--- a/directory.cabal
+++ b/directory.cabal
@@ -58,7 +58,7 @@ Library
         time     >= 1.4 && < 1.11,
         filepath >= 1.3 && < 1.5
     if os(windows)
-        build-depends: Win32 >= 2.2.2 && < 2.10
+        build-depends: Win32 >= 2.2.2 && < 2.11
     else
         build-depends: unix >= 2.5.1 && < 2.9
 

--- a/directory.cabal
+++ b/directory.cabal
@@ -55,7 +55,7 @@ Library
 
     build-depends:
         base     >= 4.5 && < 4.17,
-        time     >= 1.4 && < 1.11,
+        time     >= 1.4 && < 1.12,
         filepath >= 1.3 && < 1.5
     if os(windows)
         build-depends: Win32 >= 2.2.2 && < 2.11


### PR DESCRIPTION
Bumps the upper bound on `time` to accommodate the 2.11 release.

Also adds some `Safe` pragmas to make explicit the safe nature of `directory`'s interfaces. This ended up being using while fixing a Safe Haskell regression in an upstream dependency.