### PR TITLE
Compatibility with Win32-2.12.0.0

### DIFF
--- a/System/Directory/Internal/Prelude.hs
+++ b/System/Directory/Internal/Prelude.hs
@@ -129,6 +129,7 @@ import Foreign.C
 import GHC.IO.Exception
   ( IOErrorType
     ( InappropriateType
+    , InvalidArgument
     , OtherError
     , UnsupportedOperation
     )

--- a/System/Directory/Internal/Windows.hsc
+++ b/System/Directory/Internal/Windows.hsc
@@ -579,10 +579,14 @@ setTimes :: FilePath -> (Maybe POSIXTime, Maybe POSIXTime) -> IO ()
 setTimes path' (atime', mtime') =
   bracket (openFileHandle path' Win32.gENERIC_WRITE)
           Win32.closeHandle $ \ handle ->
+#if MIN_VERSION_Win32(2,12,0)
+  Win32.setFileTime handle Nothing (posixToWindowsTime <$> atime') (posixToWindowsTime <$> mtime')
+#else
   maybeWith with (posixToWindowsTime <$> atime') $ \ atime'' ->
   maybeWith with (posixToWindowsTime <$> mtime') $ \ mtime'' ->
   Win32.failIf_ not "" $
     Win32.c_SetFileTime handle nullPtr atime'' mtime''
+#endif
 
 -- | Open the handle of an existing file or directory.
 openFileHandle :: String -> Win32.AccessMode -> IO Win32.HANDLE

--- a/directory.cabal
+++ b/directory.cabal
@@ -58,7 +58,7 @@ Library
         time     >= 1.4 && < 1.12,
         filepath >= 1.3 && < 1.5
     if os(windows)
-        build-depends: Win32 >= 2.2.2 && < 2.12
+        build-depends: Win32 >= 2.2.2 && < 2.13
     else
         build-depends: unix >= 2.5.1 && < 2.9
 

--- a/tests/CreateDirectoryIfMissing001.hs
+++ b/tests/CreateDirectoryIfMissing001.hs
@@ -81,7 +81,10 @@ main _t = do
     -- (see bug #2924 on GHC Trac)
     create =
       createDirectoryIfMissing True testdir_a `catch` \ e ->
-      if isDoesNotExistError e || isPermissionError e || isInappropriateTypeError e
+      if isDoesNotExistError e
+         || isPermissionError e
+         || isInappropriateTypeError e
+         || ioeGetErrorType e == InvalidArgument
       then return ()
       else ioError e
 


### PR DESCRIPTION
Updated use of `setFileTime` to account for change in type; this was a
nice simplification.