### PR TITLE
Add support for XDG_STATE_HOME.

### DIFF
--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -1569,6 +1569,7 @@ getXdgDirectory xdgDir suffix =
         XdgData   -> "XDG_DATA_HOME"
         XdgConfig -> "XDG_CONFIG_HOME"
         XdgCache  -> "XDG_CACHE_HOME"
+        XdgState  -> "XDG_STATE_HOME"
       case env of
         Just path | isAbsolute path -> pure path
         _                           -> getXdgDirectoryFallback getHomeDirectory xdgDir

--- a/System/Directory/Internal/Common.hs
+++ b/System/Directory/Internal/Common.hs
@@ -271,6 +271,14 @@ data XdgDirectory
     -- On Windows, the default is @%LOCALAPPDATA%@
     -- (e.g. @C:\/Users\//\<user\>/\/AppData\/Local@).
     -- Can be considered as the user-specific equivalent of @\/var\/cache@.
+  | XdgState
+   -- ^ For data that should persist between (application) restarts,
+   -- but that is not important or portable enough to the user that it
+   -- should be stored in 'XdgData'.
+   -- It uses the @XDG_STATE_HOME@ environment variable.
+   -- On non-Windows sytems, the default is @~\/.local\/state@.  On
+   -- Windows, the default is @%LOCALAPPDATA%@
+   -- (e.g. @C:\/Users\//\<user\>/\/AppData\/Local@).
   deriving (Bounded, Enum, Eq, Ord, Read, Show)
 
 -- | Search paths for various application data, as specified by the

--- a/System/Directory/Internal/Posix.hsc
+++ b/System/Directory/Internal/Posix.hsc
@@ -296,6 +296,7 @@ getXdgDirectoryFallback getHomeDirectory xdgDir = do
     XdgData   -> ".local/share"
     XdgConfig -> ".config"
     XdgCache  -> ".cache"
+    XdgState  -> ".local/state"
 
 getXdgDirectoryListFallback :: XdgDirectoryList -> IO [FilePath]
 getXdgDirectoryListFallback xdgDirs =

--- a/System/Directory/Internal/Windows.hsc
+++ b/System/Directory/Internal/Windows.hsc
@@ -656,6 +656,7 @@ getXdgDirectoryFallback _ xdgDir = do
     XdgData   -> getFolderPath Win32.cSIDL_APPDATA
     XdgConfig -> getFolderPath Win32.cSIDL_APPDATA
     XdgCache  -> getFolderPath win32_cSIDL_LOCAL_APPDATA
+    XdgState  -> getFolderPath win32_cSIDL_LOCAL_APPDATA
 
 getXdgDirectoryListFallback :: XdgDirectoryList -> IO [FilePath]
 getXdgDirectoryListFallback _ =

--- a/tests/GetHomeDirectory001.hs
+++ b/tests/GetHomeDirectory001.hs
@@ -10,6 +10,7 @@ main _t = do
   _ <- getXdgDirectory XdgCache  "test"
   _ <- getXdgDirectory XdgConfig "test"
   _ <- getXdgDirectory XdgData   "test"
+  _ <- getXdgDirectory XdgCache  "test"
   _ <- getUserDocumentsDirectory
   _ <- getTemporaryDirectory
   return ()

--- a/tests/Xdg.hs
+++ b/tests/Xdg.hs
@@ -31,17 +31,21 @@ main _t = do
   unsetEnv "XDG_DATA_HOME"
   unsetEnv "XDG_CONFIG_HOME"
   unsetEnv "XDG_CACHE_HOME"
+  unsetEnv "XDG_STATE_HOME"
   xdgData   <- getXdgDirectory XdgData   "ff"
   xdgConfig <- getXdgDirectory XdgConfig "oo"
   xdgCache  <- getXdgDirectory XdgCache  "rk"
+  xdgState  <- getXdgDirectory XdgState  "aa"
 
   -- non-absolute paths are ignored, and the fallback is used
   setEnv "XDG_DATA_HOME"   "ar"
   setEnv "XDG_CONFIG_HOME" "aw"
   setEnv "XDG_CACHE_HOME"  "ba"
+  setEnv "XDG_STATE_HOME"  "uw"
   T(expectEq) () xdgData   =<< getXdgDirectory XdgData   "ff"
   T(expectEq) () xdgConfig =<< getXdgDirectory XdgConfig "oo"
   T(expectEq) () xdgCache  =<< getXdgDirectory XdgCache  "rk"
+  T(expectEq) () xdgState  =<< getXdgDirectory XdgState  "aa"
 
   unsetEnv "XDG_CONFIG_DIRS"
   unsetEnv "XDG_DATA_DIRS"


### PR DESCRIPTION
The lastest version of the XDG spec adds XDG_STATE_HOME for persistent data.

On Windows, we treat XdgState the same as XdgCache.  This might not be optimal, but I have no idea what (if anything) would be better on Windows.  Last I used Windows, programs just put whatever they wanted in `C:\Windows/System32`.

Requested in #119 (and would be really nice for `cabal`).