### PR TITLE
Add support for `~/.local/bin`

### DIFF
--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -1565,11 +1565,12 @@ getXdgDirectory :: XdgDirectory         -- ^ which special directory
 getXdgDirectory xdgDir suffix =
   (`ioeAddLocation` "getXdgDirectory") `modifyIOError` do
     simplify . (</> suffix) <$> do
-      env <- lookupEnv $ case xdgDir of
-        XdgData   -> "XDG_DATA_HOME"
-        XdgConfig -> "XDG_CONFIG_HOME"
-        XdgCache  -> "XDG_CACHE_HOME"
-        XdgState  -> "XDG_STATE_HOME"
+      env <- case xdgDir of
+        XdgData   -> lookupEnv "XDG_DATA_HOME"
+        XdgConfig -> lookupEnv "XDG_CONFIG_HOME"
+        XdgCache  -> lookupEnv "XDG_CACHE_HOME"
+        XdgState  -> lookupEnv "XDG_STATE_HOME"
+        XdgBin    -> pure Nothing
       case env of
         Just path | isAbsolute path -> pure path
         _                           -> getXdgDirectoryFallback getHomeDirectory xdgDir

--- a/System/Directory/Internal/Common.hs
+++ b/System/Directory/Internal/Common.hs
@@ -281,6 +281,20 @@ data XdgDirectory
    -- (e.g. @C:\/Users\//\<user\>/\/AppData\/Local@).
    --
    -- @since 1.3.7.0
+  | XdgBin
+    -- ^ For user-specific executable files.
+    -- At the moment there is no environment variable to override this value
+    -- specifically. Some applications use currently non-standard
+    -- @XDG_BIN_HOME@ for this purpose. If this is your use case then lookup
+    -- @XDG_BIN_HOME@ environment variable first and call `getXdgDirectory` if
+    -- it's not defined.
+    -- On non-Windows systems, the default is @~\/.local\/bin@.
+    -- On Windows, the default is @%APPDATA%@
+    -- (e.g. @C:\/Users\//\<user\>/\/AppData\/Roaming@).
+    -- Can be considered as the user-specific equivalent of @\/usr\/bin@ or
+    -- @\/usr\/local\/bin@.
+    --
+    -- @since 1.3.8.0
   deriving (Bounded, Enum, Eq, Ord, Read, Show)
 
 -- | Search paths for various application data, as specified by the

--- a/System/Directory/Internal/Posix.hsc
+++ b/System/Directory/Internal/Posix.hsc
@@ -297,6 +297,7 @@ getXdgDirectoryFallback getHomeDirectory xdgDir = do
     XdgConfig -> ".config"
     XdgCache  -> ".cache"
     XdgState  -> ".local/state"
+    XdgBin    -> ".local/bin"
 
 getXdgDirectoryListFallback :: XdgDirectoryList -> IO [FilePath]
 getXdgDirectoryListFallback xdgDirs =

--- a/System/Directory/Internal/Windows.hsc
+++ b/System/Directory/Internal/Windows.hsc
@@ -657,6 +657,7 @@ getXdgDirectoryFallback _ xdgDir = do
     XdgConfig -> getFolderPath Win32.cSIDL_APPDATA
     XdgCache  -> getFolderPath win32_cSIDL_LOCAL_APPDATA
     XdgState  -> getFolderPath win32_cSIDL_LOCAL_APPDATA
+    XdgBin    -> getFolderPath Win32.cSIDL_APPDATA
 
 getXdgDirectoryListFallback :: XdgDirectoryList -> IO [FilePath]
 getXdgDirectoryListFallback _ =


### PR DESCRIPTION
Proposed implementation for `XdgBin` based on the discussion in #119.

What makes `~/.local/bin` different from others is that it doesn't have an environment variable associated with it. Not everyone is happy with that [gitlab.freedesktop.org/xdg/xdg-specs/-/issues/14](https://gitlab.freedesktop.org/xdg/xdg-specs/-/issues/14) and it is possible that the situation will change in the future. Notable example is `ghcup`, which uses `XDG_BIN_HOME`.

I've looked into tests that are available for XDG stuff and they don't seem to need any changes. Please, let me know if that's not true.