### PR TITLE
Check for realpath function in autoconf

### DIFF
--- a/System/Directory/Internal/Posix.hsc
+++ b/System/Directory/Internal/Posix.hsc
@@ -49,7 +49,16 @@ c_PATH_MAX | c_PATH_MAX' > toInteger maxValue = Nothing
 c_PATH_MAX = Nothing
 #endif
 
+#if !defined(HAVE_REALPATH)
+
+c_realpath :: CString -> CString -> IO CString
+c_realpath _ _ = throwIO (mkIOError UnsupportedOperation "platform does not support realpath" Nothing Nothing)
+
+#else
+
 foreign import ccall "realpath" c_realpath :: CString -> CString -> IO CString
+
+#endif
 
 withRealpath :: CString -> (CString -> IO a) -> IO a
 withRealpath path action = case c_PATH_MAX of

--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,7 @@ AC_PROG_CC()
 # check for specific header (.h) files that we are interested in
 AC_CHECK_HEADERS([fcntl.h limits.h sys/types.h sys/stat.h time.h])
 
+AC_CHECK_FUNCS([realpath])
 AC_CHECK_FUNCS([utimensat])
 AC_CHECK_FUNCS([CreateSymbolicLinkW])
 AC_CHECK_FUNCS([GetFinalPathNameByHandleW])


### PR DESCRIPTION
In case it doesn't exist (e.g. in wasi-libc), c_realpath should unconditionally return a null pointer to indicate failure.