### PR TITLE
Add AFPP support

### DIFF
--- a/System/Directory/Internal/Config.hs
+++ b/System/Directory/Internal/Config.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE CPP #-}
 module System.Directory.Internal.Config where
 #include <HsDirectoryConfig.h>
+import System.Directory.Internal.Common
 
-exeExtension :: String
-exeExtension = EXE_EXTENSION
+exeExtension :: OsString
+exeExtension = os EXE_EXTENSION
 -- We avoid using #const_str from hsc because it breaks cross-compilation
 -- builds, so we use this ugly workaround where we simply paste the C string
 -- literal directly in here.  This will probably break if the EXE_EXTENSION

--- a/System/Directory/Internal/Posix.hsc
+++ b/System/Directory/Internal/Posix.hsc
@@ -13,24 +13,29 @@ import System.Directory.Internal.Common
 import System.Directory.Internal.Config (exeExtension)
 import Data.Time (UTCTime)
 import Data.Time.Clock.POSIX (POSIXTime)
-import System.FilePath ((</>), isRelative, splitSearchPath)
+import System.OsPath ((</>), encodeFS, isRelative, splitSearchPath)
+import System.OsString.Internal.Types (OsString(OsString, getOsString))
 import qualified Data.Time.Clock.POSIX as POSIXTime
-import qualified GHC.Foreign as GHC
-import qualified System.Posix as Posix
-import qualified System.Posix.User as PU
+import qualified System.Posix.Directory.PosixPath as Posix
+import qualified System.Posix.Env.PosixString as Posix
+import qualified System.Posix.Files.PosixString as Posix
+import qualified System.Posix.IO.PosixString as Posix
+import qualified System.Posix.PosixPath.FilePath as Posix
+import qualified System.Posix.Types as Posix
+import qualified System.Posix.User as Posix
 
-createDirectoryInternal :: FilePath -> IO ()
-createDirectoryInternal path = Posix.createDirectory path 0o777
+createDirectoryInternal :: OsPath -> IO ()
+createDirectoryInternal (OsString path) = Posix.createDirectory path 0o777
 
-removePathInternal :: Bool -> FilePath -> IO ()
-removePathInternal True  = Posix.removeDirectory
-removePathInternal False = Posix.removeLink
+removePathInternal :: Bool -> OsPath -> IO ()
+removePathInternal True  = Posix.removeDirectory . getOsString
+removePathInternal False = Posix.removeLink . getOsString
 
-renamePathInternal :: FilePath -> FilePath -> IO ()
-renamePathInternal = Posix.rename
+renamePathInternal :: OsPath -> OsPath -> IO ()
+renamePathInternal (OsString p1) (OsString p2) = Posix.rename p1 p2
 
 -- | On POSIX, equivalent to 'simplifyPosix'.
-simplify :: FilePath -> FilePath
+simplify :: OsPath -> OsPath
 simplify = simplifyPosix
 
 -- we use the 'free' from the standard library here since it's not entirely
@@ -71,31 +76,31 @@ withRealpath path action = case c_PATH_MAX of
     allocaBytes (pathMax + 1) (realpath >=> action)
   where realpath = throwErrnoIfNull "" . c_realpath path
 
-canonicalizePathWith :: ((FilePath -> IO FilePath) -> FilePath -> IO FilePath)
-                     -> FilePath
-                     -> IO FilePath
+canonicalizePathWith :: ((OsPath -> IO OsPath) -> OsPath -> IO OsPath)
+                     -> OsPath
+                     -> IO OsPath
 canonicalizePathWith attemptRealpath path = do
-  encoding <- getFileSystemEncoding
-  let realpath path' =
-        GHC.withCString encoding path' (`withRealpath` GHC.peekCString encoding)
+  let realpath (OsString path') =
+        Posix.withFilePath path'
+          (`withRealpath` ((OsString <$>) . Posix.peekFilePath))
   attemptRealpath realpath path
 
-canonicalizePathSimplify :: FilePath -> IO FilePath
+canonicalizePathSimplify :: OsPath -> IO OsPath
 canonicalizePathSimplify = pure
 
-findExecutablesLazyInternal :: ([FilePath] -> String -> ListT IO FilePath)
-                            -> String
-                            -> ListT IO FilePath
+findExecutablesLazyInternal :: ([OsPath] -> OsString -> ListT IO OsPath)
+                            -> OsString
+                            -> ListT IO OsPath
 findExecutablesLazyInternal findExecutablesInDirectoriesLazy binary =
   liftJoinListT $ do
     path <- getPath
     pure (findExecutablesInDirectoriesLazy path binary)
 
-exeExtensionInternal :: String
+exeExtensionInternal :: OsString
 exeExtensionInternal = exeExtension
 
-getDirectoryContentsInternal :: FilePath -> IO [FilePath]
-getDirectoryContentsInternal path =
+getDirectoryContentsInternal :: OsPath -> IO [OsPath]
+getDirectoryContentsInternal (OsString path) =
   bracket
     (Posix.openDirStream path)
     Posix.closeDirStream
@@ -105,12 +110,12 @@ getDirectoryContentsInternal path =
       where
         loop acc = do
           e <- Posix.readDirStream dirp
-          if null e
+          if e == mempty
             then pure (acc [])
-            else loop (acc . (e:))
+            else loop (acc . (OsString e :))
 
-getCurrentDirectoryInternal :: IO FilePath
-getCurrentDirectoryInternal = Posix.getWorkingDirectory
+getCurrentDirectoryInternal :: IO OsPath
+getCurrentDirectoryInternal = OsString <$> Posix.getWorkingDirectory
 
 -- | Convert a path into an absolute path.  If the given path is relative, the
 -- current directory is prepended and the path may or may not be simplified.
@@ -121,33 +126,34 @@ getCurrentDirectoryInternal = Posix.getWorkingDirectory
 -- operation may throw exceptions.
 --
 -- Empty paths are treated as the current directory.
-prependCurrentDirectory :: FilePath -> IO FilePath
+prependCurrentDirectory :: OsPath -> IO OsPath
 prependCurrentDirectory path
   | isRelative path =
     ((`ioeAddLocation` "prependCurrentDirectory") .
-     (`ioeSetFileName` path)) `modifyIOError` do
+     (`ioeSetOsPath` path)) `modifyIOError` do
       (</> path) <$> getCurrentDirectoryInternal
   | otherwise = pure path
 
-setCurrentDirectoryInternal :: FilePath -> IO ()
-setCurrentDirectoryInternal = Posix.changeWorkingDirectory
+setCurrentDirectoryInternal :: OsPath -> IO ()
+setCurrentDirectoryInternal = Posix.changeWorkingDirectory . getOsString
 
 linkToDirectoryIsDirectory :: Bool
 linkToDirectoryIsDirectory = False
 
-createSymbolicLink :: Bool -> FilePath -> FilePath -> IO ()
-createSymbolicLink _ = Posix.createSymbolicLink
+createSymbolicLink :: Bool -> OsPath -> OsPath -> IO ()
+createSymbolicLink _ (OsString p1) (OsString p2) =
+  Posix.createSymbolicLink p1 p2
 
-readSymbolicLink :: FilePath -> IO FilePath
-readSymbolicLink = Posix.readSymbolicLink
+readSymbolicLink :: OsPath -> IO OsPath
+readSymbolicLink = (OsString <$>) . Posix.readSymbolicLink . getOsString
 
 type Metadata = Posix.FileStatus
 
-getSymbolicLinkMetadata :: FilePath -> IO Metadata
-getSymbolicLinkMetadata = Posix.getSymbolicLinkStatus
+getSymbolicLinkMetadata :: OsPath -> IO Metadata
+getSymbolicLinkMetadata = Posix.getSymbolicLinkStatus . getOsString
 
-getFileMetadata :: FilePath -> IO Metadata
-getFileMetadata = Posix.getFileStatus
+getFileMetadata :: OsPath -> IO Metadata
+getFileMetadata = Posix.getFileStatus . getOsString
 
 fileTypeFromMetadata :: Metadata -> FileType
 fileTypeFromMetadata stat
@@ -187,19 +193,20 @@ setWriteMode :: Bool -> Mode -> Mode
 setWriteMode False m = m .&. complement allWriteMode
 setWriteMode True  m = m .|. allWriteMode
 
-setFileMode :: FilePath -> Mode -> IO ()
-setFileMode = Posix.setFileMode
+setFileMode :: OsPath -> Mode -> IO ()
+setFileMode = Posix.setFileMode . getOsString
 
-setFilePermissions :: FilePath -> Mode -> IO ()
+setFilePermissions :: OsPath -> Mode -> IO ()
 setFilePermissions = setFileMode
 
-getAccessPermissions :: FilePath -> IO Permissions
+getAccessPermissions :: OsPath -> IO Permissions
 getAccessPermissions path = do
   m <- getFileMetadata path
   let isDir = fileTypeIsDirectory (fileTypeFromMetadata m)
-  r <- Posix.fileAccess path True  False False
-  w <- Posix.fileAccess path False True  False
-  x <- Posix.fileAccess path False False True
+  let OsString path' = path
+  r <- Posix.fileAccess path' True  False False
+  w <- Posix.fileAccess path' False True  False
+  x <- Posix.fileAccess path' False False True
   pure Permissions
        { readable   = r
        , writable   = w
@@ -207,7 +214,7 @@ getAccessPermissions path = do
        , searchable = x && isDir
        }
 
-setAccessPermissions :: FilePath -> Permissions -> IO ()
+setAccessPermissions :: OsPath -> Permissions -> IO ()
 setAccessPermissions path (Permissions r w e s) = do
   m <- getFileMetadata path
   setFileMode path (modifyBit (e || s) Posix.ownerExecuteMode .
@@ -219,59 +226,77 @@ setAccessPermissions path (Permissions r w e s) = do
     modifyBit False b m = m .&. complement b
     modifyBit True  b m = m .|. b
 
-copyOwnerFromStatus :: Posix.FileStatus -> FilePath -> IO ()
-copyOwnerFromStatus st dst = do
+copyOwnerFromStatus :: Posix.FileStatus -> OsPath -> IO ()
+copyOwnerFromStatus st (OsString dst) = do
   Posix.setOwnerAndGroup dst (Posix.fileOwner st) (-1)
 
-copyGroupFromStatus :: Posix.FileStatus -> FilePath -> IO ()
-copyGroupFromStatus st dst = do
+copyGroupFromStatus :: Posix.FileStatus -> OsPath -> IO ()
+copyGroupFromStatus st (OsString dst) = do
   Posix.setOwnerAndGroup dst (-1) (Posix.fileGroup st)
 
-tryCopyOwnerAndGroupFromStatus :: Posix.FileStatus -> FilePath -> IO ()
+tryCopyOwnerAndGroupFromStatus :: Posix.FileStatus -> OsPath -> IO ()
 tryCopyOwnerAndGroupFromStatus st dst = do
   ignoreIOExceptions (copyOwnerFromStatus st dst)
   ignoreIOExceptions (copyGroupFromStatus st dst)
+
+defaultOpenFlags :: Posix.OpenFileFlags
+defaultOpenFlags =
+  Posix.defaultFileFlags
+  { Posix.noctty = True
+  , Posix.nonBlock = True
+  , Posix.creat = Just 0o666
+  }
+
+openFileForRead :: OsPath -> IO Handle
+openFileForRead (OsString p) =
+  Posix.fdToHandle =<< Posix.openFd p Posix.ReadOnly defaultOpenFlags
+
+openFileForWrite :: OsPath -> IO Handle
+openFileForWrite (OsString p) =
+  Posix.fdToHandle =<<
+    Posix.openFd p Posix.WriteOnly defaultOpenFlags { Posix.trunc = True }
 
 -- | Truncate the destination file and then copy the contents of the source
 -- file to the destination file.  If the destination file already exists, its
 -- attributes shall remain unchanged.  Otherwise, its attributes are reset to
 -- the defaults.
-copyFileContents :: FilePath            -- ^ Source filename
-                 -> FilePath            -- ^ Destination filename
+copyFileContents :: OsPath              -- ^ Source filename
+                 -> OsPath              -- ^ Destination filename
                  -> IO ()
 copyFileContents fromFPath toFPath =
   (`ioeAddLocation` "copyFileContents") `modifyIOError` do
-    withBinaryFile toFPath WriteMode $ \ hTo -> do
-      withBinaryFile fromFPath ReadMode $ \ hFrom -> do
+    withBinaryHandle (openFileForWrite toFPath) $ \ hTo -> do
+      withBinaryHandle (openFileForRead fromFPath) $ \ hFrom -> do
         copyHandleData hFrom hTo
 
-copyFileWithMetadataInternal :: (Metadata -> FilePath -> IO ())
-                             -> (Metadata -> FilePath -> IO ())
-                             -> FilePath
-                             -> FilePath
+copyFileWithMetadataInternal :: (Metadata -> OsPath -> IO ())
+                             -> (Metadata -> OsPath -> IO ())
+                             -> OsPath
+                             -> OsPath
                              -> IO ()
 copyFileWithMetadataInternal copyPermissionsFromMetadata
                              copyTimesFromMetadata
                              src
                              dst = do
-  st <- Posix.getFileStatus src
+  st <- Posix.getFileStatus (getOsString src)
   copyFileContents src dst
   tryCopyOwnerAndGroupFromStatus st dst
   copyPermissionsFromMetadata st dst
   copyTimesFromMetadata st dst
 
-setTimes :: FilePath -> (Maybe POSIXTime, Maybe POSIXTime) -> IO ()
+setTimes :: OsPath -> (Maybe POSIXTime, Maybe POSIXTime) -> IO ()
 #ifdef HAVE_UTIMENSAT
-setTimes path' (atime', mtime') =
-  withFilePath path' $ \ path'' ->
+setTimes (OsString path') (atime', mtime') =
+  Posix.withFilePath path' $ \ path'' ->
   withArray [ maybe utimeOmit toCTimeSpec atime'
             , maybe utimeOmit toCTimeSpec mtime' ] $ \ times ->
-  throwErrnoPathIfMinus1_ "" path' $
+  Posix.throwErrnoPathIfMinus1_ "" path' $
     c_utimensat c_AT_FDCWD path'' times 0
 #else
-setTimes path' (Just atime', Just mtime') = Posix.setFileTimesHiRes path' atime' mtime'
-setTimes path' (atime', mtime') = do
-  m <- getFileMetadata path'
+setTimes (OsString path') (Just atime', Just mtime') =
+  Posix.setFileTimesHiRes path' atime' mtime'
+setTimes (OsString path') (atime', mtime') = do
+  m <- getFileMetadata (OsString path')
   let atimeOld = accessTimeFromMetadata m
   let mtimeOld = modificationTimeFromMetadata m
   Posix.setFileTimesHiRes path'
@@ -279,41 +304,62 @@ setTimes path' (atime', mtime') = do
     (fromMaybe (POSIXTime.utcTimeToPOSIXSeconds mtimeOld) mtime')
 #endif
 
+lookupEnvOs :: OsString -> IO (Maybe OsString)
+lookupEnvOs (OsString name) = (OsString <$>) <$> Posix.getEnv name
+
+getEnvOs :: OsString -> IO OsString
+getEnvOs name = do
+  env <- lookupEnvOs name
+  case env of
+    Nothing ->
+      throwIO $
+        mkIOError
+          doesNotExistErrorType
+          ("env var " <> show name <> " not found")
+          Nothing
+          Nothing
+    Just value -> pure value
+
 -- | Get the contents of the @PATH@ environment variable.
-getPath :: IO [FilePath]
-getPath = splitSearchPath <$> getEnv "PATH"
+getPath :: IO [OsPath]
+getPath = splitSearchPath <$> getEnvOs (os "PATH")
 
 -- | $HOME is preferred, because the user has control over it. However, POSIX
 -- doesn't define it as a mandatory variable, so fall back to `getpwuid_r`.
-getHomeDirectoryInternal :: IO FilePath
+getHomeDirectoryInternal :: IO OsPath
 getHomeDirectoryInternal = do
-  e <- lookupEnv "HOME"
+  e <- lookupEnvOs (os "HOME")
   case e of
        Just fp -> pure fp
-       Nothing -> PU.homeDirectory <$> (PU.getEffectiveUserID >>= PU.getUserEntryForID)
+       -- TODO: os here is bad, but unix's System.Posix.User.UserEntry does not
+       -- have ByteString/OsString variants
+       Nothing ->
+         encodeFS =<<
+         Posix.homeDirectory <$>
+           (Posix.getEffectiveUserID >>= Posix.getUserEntryForID)
 
-getXdgDirectoryFallback :: IO FilePath -> XdgDirectory -> IO FilePath
+getXdgDirectoryFallback :: IO OsPath -> XdgDirectory -> IO OsPath
 getXdgDirectoryFallback getHomeDirectory xdgDir = do
   (<$> getHomeDirectory) $ flip (</>) $ case xdgDir of
-    XdgData   -> ".local/share"
-    XdgConfig -> ".config"
-    XdgCache  -> ".cache"
-    XdgState  -> ".local/state"
+    XdgData   -> os ".local/share"
+    XdgConfig -> os ".config"
+    XdgCache  -> os ".cache"
+    XdgState  -> os ".local/state"
 
-getXdgDirectoryListFallback :: XdgDirectoryList -> IO [FilePath]
+getXdgDirectoryListFallback :: XdgDirectoryList -> IO [OsPath]
 getXdgDirectoryListFallback xdgDirs =
   pure $ case xdgDirs of
-    XdgDataDirs   -> ["/usr/local/share/", "/usr/share/"]
-    XdgConfigDirs -> ["/etc/xdg"]
+    XdgDataDirs   -> [os "/usr/local/share/", os "/usr/share/"]
+    XdgConfigDirs -> [os "/etc/xdg"]
 
-getAppUserDataDirectoryInternal :: FilePath -> IO FilePath
+getAppUserDataDirectoryInternal :: OsPath -> IO OsPath
 getAppUserDataDirectoryInternal appName =
-  (\ home -> home <> ('/' : '.' : appName)) <$> getHomeDirectoryInternal
+  (\ home -> home <> (os "/" <> os "." <> appName)) <$> getHomeDirectoryInternal
 
-getUserDocumentsDirectoryInternal :: IO FilePath
+getUserDocumentsDirectoryInternal :: IO OsPath
 getUserDocumentsDirectoryInternal = getHomeDirectoryInternal
 
-getTemporaryDirectoryInternal :: IO FilePath
-getTemporaryDirectoryInternal = fromMaybe "/tmp" <$> lookupEnv "TMPDIR"
+getTemporaryDirectoryInternal :: IO OsPath
+getTemporaryDirectoryInternal = fromMaybe (os "/tmp") <$> lookupEnvOs (os "TMPDIR")
 
 #endif

--- a/System/Directory/Internal/Prelude.hs
+++ b/System/Directory/Internal/Prelude.hs
@@ -27,12 +27,10 @@ module System.Directory.Internal.Prelude
   , module System.Exit
   , module System.IO
   , module System.IO.Error
-  , module System.Posix.Internals
   , module System.Posix.Types
   , module System.Timeout
   , Void
   ) where
-import System.Environment (lookupEnv)
 import Data.Void (Void)
 import Control.Arrow (second)
 import Control.Concurrent
@@ -49,6 +47,7 @@ import Control.Exception
   , SomeException
   , bracket
   , bracket_
+  , bracketOnError
   , catch
   , finally
   , mask
@@ -97,14 +96,9 @@ import Foreign.C
   , CUShort(..)
   , CWString
   , CWchar(..)
-  , peekCString
-  , peekCWStringLen
   , throwErrnoIfMinus1Retry_
   , throwErrnoIfMinus1_
   , throwErrnoIfNull
-  , throwErrnoPathIfMinus1_
-  , withCString
-  , withCWString
   )
 import GHC.IO.Exception
   ( IOErrorType
@@ -115,7 +109,7 @@ import GHC.IO.Exception
     )
   )
 import GHC.IO.Encoding (getFileSystemEncoding)
-import System.Environment (getArgs, getEnv)
+import System.Environment (getArgs)
 import System.Exit (exitFailure)
 import System.IO
   ( Handle
@@ -129,11 +123,11 @@ import System.IO
   , openBinaryTempFile
   , stderr
   , stdout
-  , withBinaryFile
   )
 import System.IO.Error
   ( IOError
   , catchIOError
+  , doesNotExistErrorType
   , illegalOperationErrorType
   , ioeGetErrorString
   , ioeGetErrorType
@@ -151,6 +145,5 @@ import System.IO.Error
   , tryIOError
   , userError
   )
-import System.Posix.Internals (withFilePath)
 import System.Posix.Types (EpochTime)
 import System.Timeout (timeout)

--- a/directory.cabal
+++ b/directory.cabal
@@ -40,10 +40,10 @@ Library
 
     exposed-modules:
         System.Directory
+        System.Directory.OsPath
         System.Directory.Internal
         System.Directory.Internal.Prelude
     other-modules:
-        System.Directory.OsPath
         System.Directory.Internal.C_utimensat
         System.Directory.Internal.Common
         System.Directory.Internal.Config
@@ -66,6 +66,7 @@ Library
 test-suite test
     default-language: Haskell2010
     other-extensions: BangPatterns, CPP
+    default-extensions: OverloadedStrings
     ghc-options:      -Wall
     hs-source-dirs:   tests
     main-is:          Main.hs

--- a/tests/CanonicalizePath.hs
+++ b/tests/CanonicalizePath.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE CPP #-}
 module CanonicalizePath where
 #include "util.inl"
-import System.FilePath ((</>), dropFileName, dropTrailingPathSeparator,
-                        normalise, takeFileName)
+import System.Directory.Internal
+import System.OsPath ((</>), dropFileName, dropTrailingPathSeparator,
+                      normalise, takeFileName)
 import TestUtils
 
 main :: TestEnv -> IO ()
@@ -141,9 +142,9 @@ main _t = do
     T(expectEq) () fooNon fooNon13
     T(expectEq) () fooNon fooNon14
     T(expectEq) () fooNon (dropFileName cfooNon15 <>
-                           (toLower <$> takeFileName cfooNon15))
+                           (os (toLower <$> so (takeFileName cfooNon15))))
     T(expectEq) () fooNon (dropFileName cfooNon16 <>
-                           (toLower <$> takeFileName cfooNon16))
+                           (os (toLower <$> so (takeFileName cfooNon16))))
     T(expectNe) () fooNon cfooNon15
     T(expectNe) () fooNon cfooNon16
 

--- a/tests/CopyFile001.hs
+++ b/tests/CopyFile001.hs
@@ -1,17 +1,18 @@
 {-# LANGUAGE CPP #-}
 module CopyFile001 where
 #include "util.inl"
-import System.FilePath ((</>))
+import System.Directory.Internal
+import System.OsPath ((</>))
 import qualified Data.List as List
 
 main :: TestEnv -> IO ()
 main _t = do
   createDirectory dir
-  writeFile (dir </> from) contents
+  writeFile (so (dir </> from)) contents
   T(expectEq) () [from] . List.sort =<< listDirectory dir
   copyFile (dir </> from) (dir </> to)
   T(expectEq) () [from, to] . List.sort =<< listDirectory dir
-  T(expectEq) () contents =<< readFile (dir </> to)
+  T(expectEq) () contents =<< readFile (so (dir </> to))
   where
     contents = "This is the data\n"
     from     = "source"

--- a/tests/CopyFile002.hs
+++ b/tests/CopyFile002.hs
@@ -1,17 +1,18 @@
 {-# LANGUAGE CPP #-}
 module CopyFile002 where
 #include "util.inl"
+import System.Directory.Internal
 import qualified Data.List as List
 
 main :: TestEnv -> IO ()
 main _t = do
   -- Similar to CopyFile001 but moves a file in the current directory
   -- (Bug #1652 on GHC Trac)
-  writeFile from contents
+  writeFile (so from) contents
   T(expectEq) () [from] . List.sort =<< listDirectory "."
   copyFile from to
   T(expectEq) () [from, to] . List.sort =<< listDirectory "."
-  T(expectEq) () contents =<< readFile to
+  T(expectEq) () contents =<< readFile (so to)
   where
     contents = "This is the data\n"
     from     = "source"

--- a/tests/CopyFileWithMetadata.hs
+++ b/tests/CopyFileWithMetadata.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 module CopyFileWithMetadata where
 #include "util.inl"
+import System.Directory.Internal
 import qualified Data.List as List
 
 main :: TestEnv -> IO ()
@@ -25,7 +26,7 @@ main _t = (`finally` cleanup) $ do
   for_ ["b", "c"] $ \ f -> do
     T(expectEq) f perm =<< getPermissions f
     T(expectEq) f mtime =<< getModificationTime f
-    T(expectEq) f contents =<< readFile f
+    T(expectEq) f contents =<< readFile (so f)
 
   where
     contents = "This is the data\n"

--- a/tests/CreateDirectoryIfMissing001.hs
+++ b/tests/CreateDirectoryIfMissing001.hs
@@ -2,7 +2,8 @@
 module CreateDirectoryIfMissing001 where
 #include "util.inl"
 import Data.Either (lefts)
-import System.FilePath ((</>), addTrailingPathSeparator)
+import System.Directory.Internal
+import System.OsPath ((</>), addTrailingPathSeparator)
 
 main :: TestEnv -> IO ()
 main _t = do
@@ -27,13 +28,13 @@ main _t = do
   T(inform) "done."
   cleanup
 
-  writeFile testdir testdir
+  writeFile (so testdir) (so testdir)
   T(expectIOErrorType) () isAlreadyExistsError $
     createDirectoryIfMissing False testdir
   removeFile testdir
   cleanup
 
-  writeFile testdir testdir
+  writeFile (so testdir) (so testdir)
   T(expectIOErrorType) () isNotADirectoryError $
     createDirectoryIfMissing True testdir_a
   removeFile testdir
@@ -43,7 +44,7 @@ main _t = do
 
     testname = "CreateDirectoryIfMissing001"
 
-    testdir = testname <> ".d"
+    testdir = os (testname <> ".d")
     testdir_a = testdir </> "a"
 
     numRepeats = T.readArg _t testname "num-repeats" 10000

--- a/tests/FindFile001.hs
+++ b/tests/FindFile001.hs
@@ -2,7 +2,8 @@
 module FindFile001 where
 #include "util.inl"
 import qualified Data.List as List
-import System.FilePath ((</>))
+import System.Directory.Internal
+import System.OsPath ((</>))
 
 main :: TestEnv -> IO ()
 main _t = do
@@ -10,8 +11,8 @@ main _t = do
   createDirectory "bar"
   createDirectory "qux"
   writeFile "foo" ""
-  writeFile ("bar" </> "foo") ""
-  writeFile ("qux" </> "foo") ":3"
+  writeFile (so ("bar" </> "foo")) ""
+  writeFile (so ("qux" </> "foo")) ":3"
 
   -- make sure findFile is lazy enough
   T(expectEq) () (Just ("." </> "foo")) =<< findFile ("." : undefined) "foo"
@@ -23,7 +24,7 @@ main _t = do
   T(expectEq) () (Just ("." </> "foo")) =<< findFile [".", "bar"] ("foo")
   T(expectEq) () (Just ("bar" </> "foo")) =<< findFile ["bar", "."] ("foo")
 
-  let f fn = (== ":3") <$> readFile fn
+  let f fn = (== ":3") <$> readFile (so fn)
   for_ (List.permutations ["qux", "bar", "."]) $ \ ds -> do
 
     let (match, noMatch) = List.partition (== "qux") ds

--- a/tests/GetDirContents001.hs
+++ b/tests/GetDirContents001.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE CPP #-}
 module GetDirContents001 where
 #include "util.inl"
-import System.FilePath ((</>))
+import System.Directory.Internal
+import System.OsPath ((</>))
 import qualified Data.List as List
 
 main :: TestEnv -> IO ()
@@ -12,8 +13,8 @@ main _t = do
   T(expectEq) () [] . List.sort =<<
     listDirectory dir
   names <- for [1 .. 100 :: Int] $ \ i -> do
-    let name = 'f' : show i
-    writeFile (dir </> name) ""
+    let name = "f" <> os (show i)
+    writeFile (so (dir </> name)) ""
     return name
   T(expectEq) () (List.sort (specials <> names)) . List.sort =<<
     getDirectoryContents dir

--- a/tests/GetFileSize.hs
+++ b/tests/GetFileSize.hs
@@ -5,10 +5,8 @@ module GetFileSize where
 main :: TestEnv -> IO ()
 main _t = do
 
-  withBinaryFile "emptyfile" WriteMode $ \ _ -> do
-    return ()
-  withBinaryFile "testfile" WriteMode $ \ h -> do
-    hPutStr h string
+  writeFile "emptyfile" ""
+  writeFile "testfile" string
 
   T(expectEq) () 0 =<< getFileSize "emptyfile"
   T(expectEq) () (fromIntegral (length string)) =<< getFileSize "testfile"

--- a/tests/LongPaths.hs
+++ b/tests/LongPaths.hs
@@ -2,7 +2,7 @@
 module LongPaths where
 #include "util.inl"
 import TestUtils
-import System.FilePath ((</>))
+import System.OsPath ((</>))
 
 main :: TestEnv -> IO ()
 main _t = do

--- a/tests/MakeAbsolute.hs
+++ b/tests/MakeAbsolute.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE CPP #-}
 module MakeAbsolute where
 #include "util.inl"
-import System.FilePath ((</>), addTrailingPathSeparator,
-                        dropTrailingPathSeparator, normalise)
+import System.OsPath ((</>), addTrailingPathSeparator,
+                      dropTrailingPathSeparator, normalise)
 #if defined(mingw32_HOST_OS)
-import System.FilePath (takeDrive)
+import System.Directory.Internal
+import System.OsPath (takeDrive, toChar, unpack)
 #endif
 
 main :: TestEnv -> IO ()
@@ -37,10 +38,10 @@ main _t = do
 
 #if defined(mingw32_HOST_OS)
   cwd <- getCurrentDirectory
-  let driveLetter = toUpper (head (takeDrive cwd))
+  let driveLetter = toUpper (toChar (head (unpack (takeDrive cwd))))
   let driveLetter' = if driveLetter == 'Z' then 'A' else succ driveLetter
-  drp1 <- makeAbsolute (driveLetter : ":foobar")
-  drp2 <- makeAbsolute (driveLetter' : ":foobar")
+  drp1 <- makeAbsolute (os (driveLetter : ":foobar"))
+  drp2 <- makeAbsolute (os (driveLetter' : ":foobar"))
   T(expectEq) () drp1 =<< makeAbsolute "foobar"
-  T(expectEq) () drp2 (driveLetter' : ":\\foobar")
+  T(expectEq) () drp2 (os (driveLetter' : ":\\foobar"))
 #endif

--- a/tests/MinimizeNameConflicts.hs
+++ b/tests/MinimizeNameConflicts.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE CPP #-}
 module MinimizeNameConflicts
   ( main
-  , module System.Directory
+  , module System.Directory.OsPath
 #if defined(mingw32_HOST_OS)
   , module System.Win32
 #else
@@ -31,4 +31,4 @@ import System.Posix hiding
 -- https://github.com/haskell/directory/issues/52
 main :: TestEnv -> IO ()
 main _t = do
-  T(expect) "no-op" True
+  T(expect) ("no-op" :: String) True

--- a/tests/RemoveDirectoryRecursive001.hs
+++ b/tests/RemoveDirectoryRecursive001.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE CPP #-}
 module RemoveDirectoryRecursive001 where
 #include "util.inl"
-import System.FilePath ((</>), normalise)
+import System.Directory.Internal
+import System.OsPath ((</>), normalise)
 import qualified Data.List as List
-import TestUtils
+import TestUtils (modifyPermissions, symlinkOrCopy)
 
 main :: TestEnv -> IO ()
 main _t = do
@@ -24,8 +25,8 @@ main _t = do
   createDirectoryIfMissing True (tmp "a/z")
   createDirectoryIfMissing True (tmp "b")
   createDirectoryIfMissing True (tmp "c")
-  writeFile (tmp "a/x/w/u") "foo"
-  writeFile (tmp "a/t")     "bar"
+  writeFile (so (tmp "a/x/w/u")) "foo"
+  writeFile (so (tmp "a/t"))     "bar"
   symlinkOrCopy (normalise "../a") (tmp "b/g")
   symlinkOrCopy (normalise "../b") (tmp "c/h")
   symlinkOrCopy (normalise "a")    (tmp "d")
@@ -85,5 +86,5 @@ main _t = do
     getDirectoryContents  tmpD
 
   where testName = "removeDirectoryRecursive001"
-        tmpD  = testName ++ ".tmp"
+        tmpD  = testName <> ".tmp"
         tmp s = tmpD </> normalise s

--- a/tests/RemovePathForcibly.hs
+++ b/tests/RemovePathForcibly.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE CPP #-}
 module RemovePathForcibly where
 #include "util.inl"
-import System.FilePath ((</>), normalise)
+import System.Directory.Internal
+import System.OsPath ((</>), normalise)
 import qualified Data.List as List
-import TestUtils
+import TestUtils (modifyPermissions, symlinkOrCopy)
 
 main :: TestEnv -> IO ()
 main _t = do
@@ -25,9 +26,9 @@ main _t = do
   createDirectoryIfMissing True (tmp "b")
   createDirectoryIfMissing True (tmp "c")
   createDirectoryIfMissing True (tmp "f")
-  writeFile (tmp "a/x/w/u") "foo"
-  writeFile (tmp "a/t")     "bar"
-  writeFile (tmp "f/s")     "qux"
+  writeFile (so (tmp "a/x/w/u")) "foo"
+  writeFile (so (tmp "a/t"))     "bar"
+  writeFile (so (tmp "f/s"))     "qux"
   symlinkOrCopy (normalise "../a") (tmp "b/g")
   symlinkOrCopy (normalise "../b") (tmp "c/h")
   symlinkOrCopy (normalise "a")    (tmp "d")
@@ -84,5 +85,5 @@ main _t = do
     getDirectoryContents  tmpD
 
   where testName = "removePathForcibly"
-        tmpD  = testName ++ ".tmp"
+        tmpD  = testName <> ".tmp"
         tmp s = tmpD </> normalise s

--- a/tests/RenameFile001.hs
+++ b/tests/RenameFile001.hs
@@ -1,14 +1,15 @@
 {-# LANGUAGE CPP #-}
 module RenameFile001 where
 #include "util.inl"
+import System.Directory.Internal
 
 main :: TestEnv -> IO ()
 main _t = do
   writeFile tmp1 contents1
-  renameFile tmp1 tmp2
+  renameFile (os tmp1) (os tmp2)
   T(expectEq) () contents1 =<< readFile tmp2
   writeFile tmp1 contents2
-  renameFile tmp2 tmp1
+  renameFile (os tmp2) (os tmp1)
   T(expectEq) () contents1 =<< readFile tmp1
   where
     tmp1 = "tmp1"

--- a/tests/RenamePath.hs
+++ b/tests/RenamePath.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 module RenamePath where
 #include "util.inl"
+import System.Directory.Internal
 
 main :: TestEnv -> IO ()
 main _t = do
@@ -11,10 +12,10 @@ main _t = do
   T(expectEq) () ["b"] =<< listDirectory "."
 
   writeFile tmp1 contents1
-  renamePath tmp1 tmp2
+  renamePath (os tmp1) (os tmp2)
   T(expectEq) () contents1 =<< readFile tmp2
   writeFile tmp1 contents2
-  renamePath tmp2 tmp1
+  renamePath (os tmp2) (os tmp1)
   T(expectEq) () contents1 =<< readFile tmp1
 
   where

--- a/tests/Simplify.hs
+++ b/tests/Simplify.hs
@@ -2,7 +2,7 @@
 module Simplify where
 #include "util.inl"
 import System.Directory.Internal (simplifyWindows)
-import System.FilePath (normalise)
+import System.OsPath (normalise)
 
 main :: TestEnv -> IO ()
 main _t = do

--- a/tests/T8482.hs
+++ b/tests/T8482.hs
@@ -1,16 +1,17 @@
 {-# LANGUAGE CPP #-}
 module T8482 where
 #include "util.inl"
+import System.Directory.Internal
 
-tmp1 :: FilePath
+tmp1 :: OsPath
 tmp1 = "T8482.tmp1"
 
-testdir :: FilePath
+testdir :: OsPath
 testdir = "T8482.dir"
 
 main :: TestEnv -> IO ()
 main _t = do
-  writeFile tmp1 "hello"
+  writeFile (so tmp1) "hello"
   createDirectory testdir
   T(expectIOErrorType) () (is InappropriateType) (renameFile testdir tmp1)
   T(expectIOErrorType) () (is InappropriateType) (renameFile tmp1    testdir)

--- a/tests/WithCurrentDirectory.hs
+++ b/tests/WithCurrentDirectory.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE CPP #-}
 module WithCurrentDirectory where
 #include "util.inl"
-import System.FilePath ((</>))
+import System.Directory.Internal
+import System.OsPath ((</>))
 import qualified Data.List as List
 
 main :: TestEnv -> IO ()
@@ -10,13 +11,13 @@ main _t = do
   -- Make sure we're starting empty
   T(expectEq) () [] . List.sort =<< listDirectory dir
   cwd <- getCurrentDirectory
-  withCurrentDirectory dir (writeFile testfile contents)
+  withCurrentDirectory dir (writeFile (so testfile) contents)
   -- Are we still in original directory?
   T(expectEq) () cwd =<< getCurrentDirectory
   -- Did the test file get created?
   T(expectEq) () [testfile] . List.sort =<< listDirectory dir
   -- Does the file contain what we expected to write?
-  T(expectEq) () contents =<< readFile (dir </> testfile)
+  T(expectEq) () contents =<< readFile (so (dir </> testfile))
   where
     testfile = "testfile"
     contents = "some data\n"

--- a/tests/Xdg.hs
+++ b/tests/Xdg.hs
@@ -4,7 +4,7 @@ import qualified Data.List as List
 import System.Environment (setEnv, unsetEnv)
 import System.FilePath (searchPathSeparator)
 #if !defined(mingw32_HOST_OS)
-import System.FilePath ((</>))
+import System.OsPath ((</>))
 #endif
 #include "util.inl"
 

--- a/tests/util.inl
+++ b/tests/util.inl
@@ -2,7 +2,8 @@
 
 import Prelude ()
 import System.Directory.Internal.Prelude
-import System.Directory
+import System.Directory.OsPath
+import TestUtils ()
 import Util (TestEnv)
 import qualified Util as T
 -- This comment prevents "T" above from being treated as the function-like


### PR DESCRIPTION
This solution is quite CPP heavy.

## Context

* https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/abstract-file-path
* https://discourse.haskell.org/t/reviving-the-abstract-filepath-proposal-afpp-in-user-space/2344

## Dependent PRs

* https://github.com/haskell/filepath/pull/103
* https://github.com/haskell/win32/pull/198
* https://github.com/haskell/unix/pull/202

## Caveats

* some code from https://github.com/hasufell/file-io needed to be inlined
* there's probably some more code we need from base
* we drop support for older `unix` and `Win32`, otherwise we can't provide the new API
* this also raises the minimum version for `bytestring` and `filepath`, there's really no way around this
* it should still be theoretically buildable with older GHCs

----

There are currently no additional tests, but the `FilePath` version shares most of the code with `AbstractFilePath`.

CI seems to partly fail, because it uses `v1`.