### PR TITLE
Use capi for syscalls that break under musl's handling of 64-bit time_t

### DIFF
--- a/System/Directory/Internal/C_utimensat.hsc
+++ b/System/Directory/Internal/C_utimensat.hsc
@@ -1,3 +1,5 @@
+{-# LANGUAGE CApiFFI #-}
+
 module System.Directory.Internal.C_utimensat where
 #include <HsDirectoryConfig.h>
 #ifdef HAVE_UTIMENSAT
@@ -41,7 +43,7 @@ toCTimeSpec t = CTimeSpec (CTime sec) (truncate $ 10 ^ (9 :: Int) * frac)
     (sec,  frac)  = if frac' < 0 then (sec' - 1, frac' + 1) else (sec', frac')
     (sec', frac') = properFraction (toRational t)
 
-foreign import ccall "utimensat" c_utimensat
+foreign import capi "sys/stat.h utimensat" c_utimensat
   :: CInt -> CString -> Ptr CTimeSpec -> CInt -> IO CInt
 
 #endif


### PR DESCRIPTION
I maintain a [repo with builds of GHC](https://github.com/redneb/ghc-alt-libc) for the musl C standard library and I encountered a subtle bug of this library that affects GHC under 32-bit architectures with musl.

In 32-bit architectures, there was a transition where the C type `time_t` was redefined to be 64-bit in order to address the Y2038 problem. The way this was handled by musl was by introducing new versions of all affected syscalls that work with 64-bit `time_t` (e.g. `utimensat_time64` is like `utimensat` but with 64-bit `time_t`). In addition, a redirect was introduced to create an alias of the new versions of these function under the old name (e.g. [here's the redirection](https://git.musl-libc.org/cgit/musl/tree/include/sys/stat.h?id=dc9285ad1dc19349c407072cc48ba70dab86de45#n119) for `utimensat`).

The problem is that this redirection is defined as a C macro in a C header file and as such, it does not get picked by GHC when the foreign function import is done via `ccall`, but works just fine when `capi` is used. So this PR changes `utimensat` to be imported with `capi`, which should be a fairly uncontroversial change.