### PR TITLE
Avoid `Data.List.{head,tail}`

### DIFF
--- a/System/Directory/Internal/Windows.hsc
+++ b/System/Directory/Internal/Windows.hsc
@@ -330,7 +330,7 @@ toExtendedLengthPath path =
       '\\' : '\\' : '?' : '\\' : _ -> simplifiedPath
       '\\' : '\\' : '.' : '\\' : _ -> simplifiedPath
       '\\' : '\\' : _ ->
-        os "\\\\?\\UNC" <> pack (tail simplifiedPath')
+        os "\\\\?\\UNC" <> pack (drop 1 simplifiedPath')
       _ -> os "\\\\?\\" <> simplifiedPath
   where simplifiedPath = simplify path
         simplifiedPath' = unpack simplifiedPath

--- a/System/Directory/OsPath.hs
+++ b/System/Directory/OsPath.hs
@@ -120,6 +120,7 @@ import System.OsPath
   , splitSearchPath
   , takeDirectory
   )
+import qualified Data.List.NonEmpty as NE
 import Data.Time (UTCTime)
 import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
 
@@ -890,7 +891,7 @@ canonicalizePath = \ path ->
 
         segments = splitDirectories path
         prefixes = scanl1 (</>) segments
-        suffixes = tail (scanr (</>) mempty segments)
+        suffixes = NE.tail (NE.scanr (</>) mempty segments)
 
         -- try to call realpath on the largest possible prefix
         realpathPrefix candidates =


### PR DESCRIPTION
CLC has approved the proposal to add `{-# WARNING #-}` to `Data.List.{head,tail}` (https://github.com/haskell/core-libraries-committee/issues/87). It means that usage of `head` and `tail` will emit compile-time warnings. 

GHC boot packages must compile with GHC HEAD without any warnings, so this PR eliminates them. 