### PR TITLE
Update the CI and cabal file to add GHC versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,11 @@ jobs:
           - { os: macos-latest, stack: lts-12.26, stack-extra-deps: "bytestring-0.11.3.0, filepath-1.4.100.0, unix-2.8.0.0" }
           - { os: macos-latest, stack: lts-19.21, stack-extra-deps: "bytestring-0.11.3.0, filepath-1.4.100.0, unix-2.8.0.0" }
           - { os: ubuntu-latest, ghc: 8.4.4, cabal: 3.0.0.0, overrides: "before_prepare() { sed -i.bak /utimensat/d configure.ac; }" }
-          - { os: ubuntu-latest, ghc: 9.0.1, cabal: 3.4.0.0 }
+          - { os: ubuntu-latest, ghc: 8.6.5, cabal: 3.0.0.0, overrides: "before_prepare() { sed -i.bak /utimensat/d configure.ac; }" }
+          - { os: ubuntu-latest, ghc: 8.10.7, cabal: 3.8.1.0 }
+          - { os: ubuntu-latest, ghc: 9.0.2, cabal: 3.8.1.0 }
+          - { os: ubuntu-latest, ghc: 9.2.4, cabal: 3.8.1.0 }
+          - { os: ubuntu-latest, ghc: 9.4.3, cabal: 3.8.1.0 }
           - { os: ubuntu-latest, ghc: latest, cabal: latest }
           - { os: windows-latest, stack: lts-12.26, stack-extra-deps: "bytestring-0.11.3.0, filepath-1.4.100.0, time-1.8.0.2, Win32-2.13.3.0", overrides: "before_prepare() { sed -i.bak -e /CreateSymbolicLinkW/d -e /GetFinalPathNameByHandleW/d configure.ac; }" }
           - { os: windows-latest, stack: lts-17.5, stack-extra-deps: "bytestring-0.11.3.0, filepath-1.4.100.0, time-1.9.3, Win32-2.13.3.0" }

--- a/directory.cabal
+++ b/directory.cabal
@@ -1,6 +1,7 @@
+cabal-version:  2.2
 name:           directory
 version:        1.3.8.0
-license:        BSD3
+license:        BSD-3-Clause
 license-file:   LICENSE
 maintainer:     libraries@haskell.org
 bug-reports:    https://github.com/haskell/directory/issues
@@ -10,8 +11,7 @@ description:
   directories in a portable way.
 category:       System
 build-type:     Configure
-cabal-version:  >= 1.10
-tested-with:    GHC>=7.4.1
+tested-with:    GHC == 8.6.5 || == 8.10.7 || == 9.0.2 || == 9.2.4 || == 9.4.3
 
 extra-tmp-files:
     autom4te.cache


### PR DESCRIPTION
This PR fixes #148.

More GHC versions are added to the CI, and the cabal file reflects those versions.