### PR TITLE
Fix test in GetHomeDirectory001.hs to use XdgState

### DIFF
--- a/tests/GetHomeDirectory001.hs
+++ b/tests/GetHomeDirectory001.hs
@@ -10,7 +10,7 @@ main _t = do
   _ <- getXdgDirectory XdgCache  "test"
   _ <- getXdgDirectory XdgConfig "test"
   _ <- getXdgDirectory XdgData   "test"
-  _ <- getXdgDirectory XdgCache  "test"
+  _ <- getXdgDirectory XdgState  "test"
   _ <- getUserDocumentsDirectory
   _ <- getTemporaryDirectory
   return ()


### PR DESCRIPTION
The previous Pull Request [Add support for XDG_STATE_HOME](https://github.com/haskell/directory/pull/121) appears to contain a copy&paste error in one of the tests. 

See here where it adds a line with `XdgCache` instead of `XdgState`:

https://github.com/haskell/directory/pull/121/files#diff-aabb252486b56d0d2bb8efedbd8f52e42a2db1b44b8bf9b75b61b6e72c7950d8R13

This pull request fixes it.