### PR TITLE
Re #132 Extend Haddock docs to be express about Windows limitation

### DIFF
--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -458,9 +458,13 @@ renameDirectory opath npath = do
 {- |@'renameFile' old new@ changes the name of an existing file system
 object from /old/ to /new/.  If the /new/ object already exists, it is
 replaced by the /old/ object.  Neither path may refer to an existing
-directory.  A conformant implementation need not support renaming files
-in all situations (e.g. renaming across different physical devices), but
-the constraints must be documented.
+directory.
+
+A conformant implementation need not support renaming files in all situations
+(e.g. renaming across different physical devices), but the constraints must be
+documented. On Windows, this does not support renaming across different physical
+devices; if you are looking to do so, consider using 'copyFileWithMetadata' and
+'removeFile'.
 
 On Windows, this calls @MoveFileEx@ with @MOVEFILE_REPLACE_EXISTING@ set,
 which is not guaranteed to be atomic

--- a/System/Directory/OsPath.hs
+++ b/System/Directory/OsPath.hs
@@ -588,9 +588,13 @@ renameDirectory opath npath =
 {- |@'renameFile' old new@ changes the name of an existing file system
 object from /old/ to /new/.  If the /new/ object already exists, it is
 replaced by the /old/ object.  Neither path may refer to an existing
-directory.  A conformant implementation need not support renaming files
-in all situations (e.g. renaming across different physical devices), but
-the constraints must be documented.
+directory.
+
+A conformant implementation need not support renaming files in all situations
+(e.g. renaming across different physical devices), but the constraints must be
+documented. On Windows, this does not support renaming across different physical
+devices; if you are looking to do so, consider using 'copyFileWithMetadata' and
+'removeFile'.
 
 On Windows, this calls @MoveFileEx@ with @MOVEFILE_REPLACE_EXISTING@ set,
 which is not guaranteed to be atomic


### PR DESCRIPTION
The motivation for this proposed extension to the Haddock documentation is that I was not aware of this limitation until I experienced an error and then searched this repository for `MoveFileEx`, finding #132.