### PR TITLE
Support filepath >= 1.5.0.0 and os-string, fixes #164

### DIFF
--- a/directory.cabal
+++ b/directory.cabal
@@ -34,6 +34,11 @@ source-repository head
     type:     git
     location: https://github.com/haskell/directory
 
+flag os-string
+  description: Use the new os-string package
+  default: False
+  manual: False
+
 Library
     default-language: Haskell2010
     other-extensions: CApiFFI, CPP
@@ -54,12 +59,16 @@ Library
 
     build-depends:
         base     >= 4.11.0 && < 4.20,
-        time     >= 1.8.0 && < 1.13,
-        filepath >= 1.4.100 && < 1.5
+        time     >= 1.8.0 && < 1.13
     if os(windows)
         build-depends: Win32 >= 2.13.3 && < 2.14
     else
         build-depends: unix >= 2.8.0 && < 2.9
+
+    if flag(os-string)
+      build-depends: filepath >= 1.5.0.0, os-string >= 2.0.0
+    else
+      build-depends: filepath >= 1.4.100.0 && < 1.4.200.0
 
     ghc-options: -Wall
 


### PR DESCRIPTION
Depends on:

* https://github.com/haskell/unix/pull/305
* https://github.com/haskell/win32/pull/226