### PR TITLE
Use extra-doc-files field for changelog.md and README.md

### DIFF
--- a/directory.cabal
+++ b/directory.cabal
@@ -19,11 +19,13 @@ extra-tmp-files:
     config.status
     HsDirectoryConfig.h
 
+extra-doc-files:
+    README.md
+    changelog.md
+
 extra-source-files:
     HsDirectoryConfig.h.in
-    README.md
     System/Directory/Internal/*.h
-    changelog.md
     configure
     configure.ac
     directory.buildinfo


### PR DESCRIPTION
The tool `cabal check` complains about the changelog being an extra-source-file instead of an extra-doc-file.