### PR TITLE
Bump base bound to allow 4.20

### DIFF
--- a/directory.cabal
+++ b/directory.cabal
@@ -60,7 +60,7 @@ Library
     include-dirs: .
 
     build-depends:
-        base     >= 4.11.0 && < 4.20,
+        base     >= 4.11.0 && < 4.21,
         time     >= 1.8.0 && < 1.15
     if os(windows)
         build-depends: Win32 >= 2.13.3 && < 2.15


### PR DESCRIPTION
For GHC 9.10