### PR TITLE
Remove "install-includes: HsDirectoryConfig.h"

### DIFF
--- a/directory.buildinfo
+++ b/directory.buildinfo
@@ -1,1 +1,0 @@
-install-includes: HsDirectoryConfig.h

--- a/directory.cabal
+++ b/directory.cabal
@@ -28,7 +28,6 @@ extra-source-files:
     System/Directory/Internal/*.h
     configure
     configure.ac
-    directory.buildinfo
     tests/*.hs
     tests/util.inl
 


### PR DESCRIPTION
This header file is not supposed to be installed for users, users are not supposed to use it. The file exists to be used interally (and this is explained by the "include-dirs" field in the cabal file.

It seems likely that this removal was overlooked in c87be9908023896a7f270bb076731ffba6c151b5