### PR TITLE
Support ghc-9.12

### DIFF
--- a/directory.cabal
+++ b/directory.cabal
@@ -59,7 +59,7 @@ Library
     include-dirs: .
 
     build-depends:
-        base     >= 4.13.0 && < 4.21,
+        base     >= 4.13.0 && < 4.22,
         file-io  >= 0.1.4 && < 0.2,
         time     >= 1.8.0 && < 1.15,
     if os(windows)


### PR DESCRIPTION
Alpha 2 of `ghc-9.12` has just been released. Can't add `ghc-9.12` to CI yet because its not available in CI.

Would appreciate a Hackage metadata update as well.