### PR TITLE
Expose getPath

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,9 @@ jobs:
           - { os: ubuntu-latest, ghc: 9.4.3, cabal: 3.8.1.0 }
           # TODO: Unpin cabal from 3.12.10 after https://github.com/haskell/cabal/issues/10718 is fixed.
           - { os: ubuntu-latest, ghc: latest, cabal: 3.12.1.0, cabal-package-flags: +os-string, ghc-flags: -Werror=deprecations }
-          - { os: windows-latest, stack: lts-15.3, stack-extra-deps: "bytestring-0.11.3.0, file-io-0.1.4, filepath-1.4.100.0, time-1.9.3, Win32-2.13.3.0", overrides: "before_prepare() { sed -i.bak -e /CreateSymbolicLinkW/d -e /GetFinalPathNameByHandleW/d configure.ac; }" }
-          - { os: windows-latest, stack: lts-17.5, stack-extra-deps: "bytestring-0.11.3.0, file-io-0.1.4, filepath-1.4.100.0, time-1.9.3, Win32-2.13.3.0" }
-          - { os: windows-latest, stack: lts-22.7, stack-extra-deps: "bytestring-0.11.5.3, file-io-0.1.4, filepath-1.5.2.0, os-string-2.0.2, time-1.14, Win32-2.14.0.0", stack-package-flags: "{directory: {os-string: true}, file-io: {os-string: true}, Win32: {os-string: true}}", ghc-flags: -Werror=deprecations }
+          - { os: windows-latest, stack: lts-15.3, stack-extra-deps: "bytestring-0.11.3.0, file-io-0.1.4, filepath-1.4.100.0, time-1.9.3, Win32-2.14.1.0", overrides: "before_prepare() { sed -i.bak -e /CreateSymbolicLinkW/d -e /GetFinalPathNameByHandleW/d configure.ac; }" }
+          - { os: windows-latest, stack: lts-17.5, stack-extra-deps: "bytestring-0.11.3.0, file-io-0.1.4, filepath-1.4.100.0, time-1.9.3, Win32-2.14.1.0" }
+          - { os: windows-latest, stack: lts-22.7, stack-extra-deps: "bytestring-0.11.5.3, file-io-0.1.4, filepath-1.5.2.0, os-string-2.0.2, time-1.14, Win32-2.14.1.0", stack-package-flags: "{directory: {os-string: true}, file-io: {os-string: true}, Win32: {os-string: true}}", ghc-flags: -Werror=deprecations }
     runs-on: ${{ matrix.os }}
     env:
       CABAL_PACKAGE_FLAGS: ${{ matrix.cabal-package-flags }}

--- a/System/Directory.hs
+++ b/System/Directory.hs
@@ -40,6 +40,9 @@ module System.Directory
     , getUserDocumentsDirectory
     , getTemporaryDirectory
 
+    -- * PATH
+    , System.Directory.getPath
+
     -- * Actions on files
     , removeFile
     , renameFile
@@ -1337,3 +1340,7 @@ The function doesn\'t verify whether the path exists.
 -}
 getTemporaryDirectory :: IO FilePath
 getTemporaryDirectory = D.getTemporaryDirectory >>= decodeFS
+
+-- | Get the contents of the @PATH@ environment variable.
+getPath :: IO [FilePath]
+getPath = D.getPath >>= (`for` decodeFS)

--- a/System/Directory/Internal/Posix.hsc
+++ b/System/Directory/Internal/Posix.hsc
@@ -148,6 +148,10 @@ findExecutablesLazyInternal findExecutablesInDirectoriesLazy binary =
     path <- getPath
     pure (findExecutablesInDirectoriesLazy path binary)
 
+-- | Get the contents of the @PATH@ environment variable.
+getPath :: IO [OsPath]
+getPath = splitSearchPath <$> getEnvOs (os "PATH")
+
 exeExtensionInternal :: OsString
 exeExtensionInternal = exeExtension
 
@@ -390,10 +394,6 @@ getEnvOs name = do
           Nothing
           Nothing
     Just value -> pure value
-
--- | Get the contents of the @PATH@ environment variable.
-getPath :: IO [OsPath]
-getPath = splitSearchPath <$> getEnvOs (os "PATH")
 
 -- | $HOME is preferred, because the user has control over it. However, POSIX
 -- doesn't define it as a mandatory variable, so fall back to `getpwuid_r`.

--- a/System/Directory/OsPath.hs
+++ b/System/Directory/OsPath.hs
@@ -42,6 +42,9 @@ module System.Directory.OsPath
     , getUserDocumentsDirectory
     , getTemporaryDirectory
 
+    -- * PATH
+    , getPath
+
     -- * Actions on files
     , removeFile
     , renameFile
@@ -1653,3 +1656,4 @@ The function doesn\'t verify whether the path exists.
 -}
 getTemporaryDirectory :: IO OsPath
 getTemporaryDirectory = getTemporaryDirectoryInternal
+

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 Changelog for the [`directory`][1] package
 ==========================================
 
+## 1.3.10.0 (XXX 2025)
+
+  * Add `getPath` wrt [#198](https://github.com/haskell/directory/pull/198)
+
 ## 1.3.9.0 (Oct 2024)
 
   * Rely on `file-io` for file I/O.

--- a/directory.cabal
+++ b/directory.cabal
@@ -1,6 +1,6 @@
 cabal-version:  2.2
 name:           directory
-version:        1.3.9.0
+version:        1.3.10.0
 license:        BSD-3-Clause
 license-file:   LICENSE
 maintainer:     libraries@haskell.org

--- a/directory.cabal
+++ b/directory.cabal
@@ -63,7 +63,7 @@ Library
         file-io  >= 0.1.4 && < 0.2,
         time     >= 1.8.0 && < 1.15,
     if os(windows)
-        build-depends: Win32 >= 2.13.3 && < 2.15
+        build-depends: Win32 >= 2.14.1.0 && < 2.15
     else
         build-depends: unix >= 2.8.0 && < 2.9
 


### PR DESCRIPTION
While working on https://github.com/haskell/filepath/pull/250 I realized I need to inline insane amounts of code. Then I found out that directory basically already has what we need in internal modules. My understanding is that this would fit well in directory API, since it also deals with XDG. So PATH doesn't seem to be far fetched.

This would also allow me to deprecate the [problematic](https://github.com/haskell/filepath/issues/251) `getSearchPath` in filepath.